### PR TITLE
add ability to use junit 5

### DIFF
--- a/.idea/modules/mqtt-bee_test.iml
+++ b/.idea/modules/mqtt-bee_test.iml
@@ -15,19 +15,30 @@
     <orderEntry type="library" name="Gradle: com.google.dagger:dagger:2.14.1" level="project" />
     <orderEntry type="library" name="Gradle: com.google.guava:guava:23.6-jre" level="project" />
     <orderEntry type="library" name="Gradle: junit:junit:4.12" level="project" />
+    <orderEntry type="library" name="Gradle: org.junit.jupiter:junit-jupiter-api:5.0.3" level="project" />
+    <orderEntry type="library" name="Gradle: org.junit.jupiter:junit-jupiter-params:5.0.3" level="project" />
     <orderEntry type="library" name="Gradle: org.reactivestreams:reactive-streams:1.0.2" level="project" />
     <orderEntry type="library" name="Gradle: io.netty:netty-buffer:4.1.19.Final" level="project" />
     <orderEntry type="library" name="Gradle: io.netty:netty-transport:4.1.19.Final" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Gradle: org.junit.vintage:junit-vintage-engine:4.12.3" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Gradle: org.junit.jupiter:junit-jupiter-engine:5.0.3" level="project" />
     <orderEntry type="library" name="Gradle: io.netty:netty-codec:4.1.19.Final" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Gradle: org.junit.platform:junit-platform-launcher:1.0.3" level="project" />
     <orderEntry type="library" name="Gradle: javax.inject:javax.inject:1" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Gradle: org.junit.platform:junit-platform-runner:1.0.3" level="project" />
     <orderEntry type="library" name="Gradle: com.google.code.findbugs:jsr305:1.3.9" level="project" />
     <orderEntry type="library" name="Gradle: org.checkerframework:checker-compat-qual:2.0.0" level="project" />
     <orderEntry type="library" name="Gradle: com.google.errorprone:error_prone_annotations:2.1.3" level="project" />
     <orderEntry type="library" name="Gradle: com.google.j2objc:j2objc-annotations:1.1" level="project" />
     <orderEntry type="library" name="Gradle: org.codehaus.mojo:animal-sniffer-annotations:1.14" level="project" />
     <orderEntry type="library" name="Gradle: org.hamcrest:hamcrest-core:1.3" level="project" />
+    <orderEntry type="library" name="Gradle: org.apiguardian:apiguardian-api:1.0.0" level="project" />
+    <orderEntry type="library" name="Gradle: org.opentest4j:opentest4j:1.0.0" level="project" />
+    <orderEntry type="library" name="Gradle: org.junit.platform:junit-platform-commons:1.0.3" level="project" />
     <orderEntry type="library" name="Gradle: io.netty:netty-common:4.1.19.Final" level="project" />
     <orderEntry type="library" name="Gradle: io.netty:netty-resolver:4.1.19.Final" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Gradle: org.junit.platform:junit-platform-engine:1.0.3" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Gradle: org.junit.platform:junit-platform-suite-api:1.0.3" level="project" />
   </component>
   <component name="TestModuleProperties" production-module="mqtt-bee_main" />
 </module>

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath group: 'org.junit.platform', name: 'junit-platform-gradle-plugin', version: '1.0.3'
+    }
+}
+
 plugins {
     id 'net.ltgt.apt' version '0.13'
 }
@@ -7,6 +16,9 @@ version '1.0-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'net.ltgt.apt'
+apply plugin: 'org.junit.platform.gradle.plugin'
+apply plugin: 'idea'
+apply plugin: 'eclipse'
 
 sourceCompatibility = 1.8
 
@@ -19,6 +31,10 @@ project.ext {
     nettyVersion = '4.1.19.Final'
     daggerVersion = '2.14.1'
     guavaVersion = '23.6-jre'
+    junit4Version = '4.12'
+    junitVintageVersion = '4.12.3'
+    junitJupiterVersion = '5.0.3'
+    junitPlatformVersion = '1.0.3'
 }
 
 dependencies {
@@ -29,5 +45,12 @@ dependencies {
 
     apt group: 'com.google.dagger', name: 'dagger-compiler', version: daggerVersion
 
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'junit', name: 'junit', version: junit4Version
+    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: junitJupiterVersion
+    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: junitJupiterVersion
+
+    testRuntime group: 'org.junit.vintage', name: 'junit-vintage-engine', version: junitVintageVersion
+    testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: junitJupiterVersion
+    testRuntime group: 'org.junit.platform', name: 'junit-platform-launcher', version: junitPlatformVersion
+    testRuntime group: 'org.junit.platform', name: 'junit-platform-runner', version: junitPlatformVersion
 }


### PR DESCRIPTION
Allow unit tests to use junit5. 
All new tests should use 5. Old tests
can still use junit 4 which is supported using vintage.