### PR TITLE
Bugfix/publish order

### DIFF
--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttAsyncClient.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttAsyncClient.java
@@ -17,7 +17,9 @@
 
 package com.hivemq.client.internal.mqtt;
 
+import com.hivemq.client.internal.mqtt.message.publish.MqttPublish;
 import com.hivemq.client.internal.mqtt.message.subscribe.MqttSubscribeBuilder;
+import com.hivemq.client.internal.mqtt.util.MqttChecks;
 import com.hivemq.client.internal.rx.RxFutureConverter;
 import com.hivemq.client.internal.util.Checks;
 import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
@@ -125,9 +127,9 @@ public class MqttAsyncClient implements Mqtt5AsyncClient {
 
     @Override
     public @NotNull CompletableFuture<@NotNull Mqtt5PublishResult> publish(final @Nullable Mqtt5Publish publish) {
-        Checks.notNull(publish, "Publish");
+        final MqttPublish mqttPublish = MqttChecks.publish(publish);
 
-        return RxFutureConverter.toFuture(delegate.publishHalfSafe(Flowable.just(publish)).singleOrError())
+        return RxFutureConverter.toFuture(delegate.publishHalfSafe(Flowable.just(mqttPublish)).singleOrError())
                 .thenApply(PUBLISH_HANDLER);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttBlockingClient.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttBlockingClient.java
@@ -72,18 +72,6 @@ public class MqttBlockingClient implements Mqtt5BlockingClient {
         return unsubAck;
     }
 
-    static @NotNull Mqtt5PublishResult handlePublish(final @NotNull Mqtt5PublishResult publishResult) {
-        final Optional<Throwable> error = publishResult.getError();
-        if (error.isPresent()) {
-            final Throwable throwable = error.get();
-            if (throwable instanceof RuntimeException) {
-                throw (RuntimeException) throwable;
-            }
-            throw new RuntimeException(throwable);
-        }
-        return publishResult;
-    }
-
     private final @NotNull MqttRxClient delegate;
 
     MqttBlockingClient(final @NotNull MqttRxClient delegate) {
@@ -126,7 +114,7 @@ public class MqttBlockingClient implements Mqtt5BlockingClient {
     public @NotNull Mqtt5PublishResult publish(final @Nullable Mqtt5Publish publish) {
         final MqttPublish mqttPublish = MqttChecks.publish(publish);
         try {
-            return handlePublish(delegate.publishUnsafe(Flowable.just(mqttPublish)).singleOrError().blockingGet());
+            return delegate.publishUnsafe(mqttPublish).blockingGet();
         } catch (final RuntimeException e) {
             throw AsyncRuntimeException.fillInStackTrace(e);
         }

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttBlockingClient.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttBlockingClient.java
@@ -17,7 +17,11 @@
 
 package com.hivemq.client.internal.mqtt;
 
+import com.hivemq.client.internal.mqtt.message.connect.MqttConnect;
+import com.hivemq.client.internal.mqtt.message.disconnect.MqttDisconnect;
 import com.hivemq.client.internal.mqtt.message.publish.MqttPublish;
+import com.hivemq.client.internal.mqtt.message.subscribe.MqttSubscribe;
+import com.hivemq.client.internal.mqtt.message.unsubscribe.MqttUnsubscribe;
 import com.hivemq.client.internal.mqtt.util.MqttChecks;
 import com.hivemq.client.internal.util.AsyncRuntimeException;
 import com.hivemq.client.internal.util.Checks;
@@ -80,8 +84,9 @@ public class MqttBlockingClient implements Mqtt5BlockingClient {
 
     @Override
     public @NotNull Mqtt5ConnAck connect(final @Nullable Mqtt5Connect connect) {
+        final MqttConnect mqttConnect = MqttChecks.connect(connect);
         try {
-            return delegate.connectUnsafe(connect).blockingGet();
+            return delegate.connectUnsafe(mqttConnect).blockingGet();
         } catch (final RuntimeException e) {
             throw AsyncRuntimeException.fillInStackTrace(e);
         }
@@ -89,8 +94,9 @@ public class MqttBlockingClient implements Mqtt5BlockingClient {
 
     @Override
     public @NotNull Mqtt5SubAck subscribe(final @Nullable Mqtt5Subscribe subscribe) {
+        final MqttSubscribe mqttSubscribe = MqttChecks.subscribe(subscribe);
         try {
-            return handleSubAck(delegate.subscribeUnsafe(subscribe).blockingGet());
+            return handleSubAck(delegate.subscribeUnsafe(mqttSubscribe).blockingGet());
         } catch (final RuntimeException e) {
             throw AsyncRuntimeException.fillInStackTrace(e);
         }
@@ -98,13 +104,16 @@ public class MqttBlockingClient implements Mqtt5BlockingClient {
 
     @Override
     public @NotNull Mqtt5Publishes publishes(final @Nullable MqttGlobalPublishFilter filter) {
+        Checks.notNull(filter, "Global publish filter");
+
         return new MqttPublishes(delegate.publishesUnsafe(filter));
     }
 
     @Override
     public @NotNull Mqtt5UnsubAck unsubscribe(final @Nullable Mqtt5Unsubscribe unsubscribe) {
+        final MqttUnsubscribe mqttUnsubscribe = MqttChecks.unsubscribe(unsubscribe);
         try {
-            return handleUnsubAck(delegate.unsubscribeUnsafe(unsubscribe).blockingGet());
+            return handleUnsubAck(delegate.unsubscribeUnsafe(mqttUnsubscribe).blockingGet());
         } catch (final RuntimeException e) {
             throw AsyncRuntimeException.fillInStackTrace(e);
         }
@@ -131,8 +140,9 @@ public class MqttBlockingClient implements Mqtt5BlockingClient {
 
     @Override
     public void disconnect(final @NotNull Mqtt5Disconnect disconnect) {
+        final MqttDisconnect mqttDisconnect = MqttChecks.disconnect(disconnect);
         try {
-            delegate.disconnectUnsafe(disconnect).blockingAwait();
+            delegate.disconnectUnsafe(mqttDisconnect).blockingAwait();
         } catch (final RuntimeException e) {
             throw AsyncRuntimeException.fillInStackTrace(e);
         }

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttBlockingClient.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttBlockingClient.java
@@ -17,6 +17,8 @@
 
 package com.hivemq.client.internal.mqtt;
 
+import com.hivemq.client.internal.mqtt.message.publish.MqttPublish;
+import com.hivemq.client.internal.mqtt.util.MqttChecks;
 import com.hivemq.client.internal.util.AsyncRuntimeException;
 import com.hivemq.client.internal.util.Checks;
 import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
@@ -122,9 +124,9 @@ public class MqttBlockingClient implements Mqtt5BlockingClient {
 
     @Override
     public @NotNull Mqtt5PublishResult publish(final @Nullable Mqtt5Publish publish) {
-        Checks.notNull(publish, "Publish");
+        final MqttPublish mqttPublish = MqttChecks.publish(publish);
         try {
-            return handlePublish(delegate.publishUnsafe(Flowable.just(publish)).singleOrError().blockingGet());
+            return handlePublish(delegate.publishUnsafe(Flowable.just(mqttPublish)).singleOrError().blockingGet());
         } catch (final RuntimeException e) {
             throw AsyncRuntimeException.fillInStackTrace(e);
         }

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttRxClient.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttRxClient.java
@@ -70,62 +70,70 @@ public class MqttRxClient implements Mqtt5RxClient {
 
     @Override
     public @NotNull Single<Mqtt5ConnAck> connect(final @Nullable Mqtt5Connect connect) {
+        return connect(MqttChecks.connect(connect));
+    }
+
+    @NotNull Single<Mqtt5ConnAck> connect(final @NotNull MqttConnect connect) {
         return connectUnsafe(connect).observeOn(clientConfig.getExecutorConfig().getApplicationScheduler());
     }
 
-    @NotNull Single<Mqtt5ConnAck> connectUnsafe(final @Nullable Mqtt5Connect connect) {
-        final MqttConnect mqttConnect = MqttChecks.connect(connect);
-
-        return new MqttConnAckSingle(clientConfig, mqttConnect);
+    @NotNull Single<Mqtt5ConnAck> connectUnsafe(final @NotNull MqttConnect connect) {
+        return new MqttConnAckSingle(clientConfig, connect);
     }
 
     @Override
     public @NotNull Single<Mqtt5SubAck> subscribe(final @Nullable Mqtt5Subscribe subscribe) {
+        return subscribe(MqttChecks.subscribe(subscribe));
+    }
+
+    @NotNull Single<Mqtt5SubAck> subscribe(final @NotNull MqttSubscribe subscribe) {
         return subscribeUnsafe(subscribe).observeOn(clientConfig.getExecutorConfig().getApplicationScheduler());
     }
 
-    @NotNull Single<Mqtt5SubAck> subscribeUnsafe(final @Nullable Mqtt5Subscribe subscribe) {
-        final MqttSubscribe mqttSubscribe = MqttChecks.subscribe(subscribe);
-
-        return new MqttSubAckSingle(mqttSubscribe, clientConfig);
+    @NotNull Single<Mqtt5SubAck> subscribeUnsafe(final @NotNull MqttSubscribe subscribe) {
+        return new MqttSubAckSingle(subscribe, clientConfig);
     }
 
     @Override
     public @NotNull FlowableWithSingle<Mqtt5Publish, Mqtt5SubAck> subscribeStream(
             final @Nullable Mqtt5Subscribe subscribe) {
 
+        return subscribeStream(MqttChecks.subscribe(subscribe));
+    }
+
+    @NotNull FlowableWithSingle<Mqtt5Publish, Mqtt5SubAck> subscribeStream(final @NotNull MqttSubscribe subscribe) {
         return subscribeStreamUnsafe(subscribe).observeOnBoth(
                 clientConfig.getExecutorConfig().getApplicationScheduler(), true);
     }
 
     @NotNull FlowableWithSingle<Mqtt5Publish, Mqtt5SubAck> subscribeStreamUnsafe(
-            final @Nullable Mqtt5Subscribe subscribe) {
+            final @NotNull MqttSubscribe subscribe) {
 
-        final MqttSubscribe mqttSubscribe = MqttChecks.subscribe(subscribe);
-
-        return new MqttSubscribedPublishFlowable(mqttSubscribe, clientConfig);
+        return new MqttSubscribedPublishFlowable(subscribe, clientConfig);
     }
 
     @Override
     public @NotNull Flowable<Mqtt5Publish> publishes(final @Nullable MqttGlobalPublishFilter filter) {
+        Checks.notNull(filter, "Global publish filter");
+
         return publishesUnsafe(filter).observeOn(clientConfig.getExecutorConfig().getApplicationScheduler(), true);
     }
 
-    @NotNull Flowable<Mqtt5Publish> publishesUnsafe(final @Nullable MqttGlobalPublishFilter filter) {
-        Checks.notNull(filter, "Global publish filter");
-
+    @NotNull Flowable<Mqtt5Publish> publishesUnsafe(final @NotNull MqttGlobalPublishFilter filter) {
         return new MqttGlobalIncomingPublishFlowable(filter, clientConfig);
     }
 
     @Override
     public @NotNull Single<Mqtt5UnsubAck> unsubscribe(final @Nullable Mqtt5Unsubscribe unsubscribe) {
+        return unsubscribe(MqttChecks.unsubscribe(unsubscribe));
+    }
+
+    @NotNull Single<Mqtt5UnsubAck> unsubscribe(final @NotNull MqttUnsubscribe unsubscribe) {
         return unsubscribeUnsafe(unsubscribe).observeOn(clientConfig.getExecutorConfig().getApplicationScheduler());
     }
 
-    @NotNull Single<Mqtt5UnsubAck> unsubscribeUnsafe(final @Nullable Mqtt5Unsubscribe unsubscribe) {
-        final MqttUnsubscribe mqttUnsubscribe = MqttChecks.unsubscribe(unsubscribe);
-
-        return new MqttUnsubAckSingle(mqttUnsubscribe, clientConfig);
+    @NotNull Single<Mqtt5UnsubAck> unsubscribeUnsafe(final @NotNull MqttUnsubscribe unsubscribe) {
+        return new MqttUnsubAckSingle(unsubscribe, clientConfig);
     }
 
     @NotNull Single<Mqtt5PublishResult> publish(final @NotNull MqttPublish publish) {
@@ -138,13 +146,13 @@ public class MqttRxClient implements Mqtt5RxClient {
 
     @Override
     public @NotNull Flowable<Mqtt5PublishResult> publish(final @Nullable Flowable<Mqtt5Publish> publishFlowable) {
+        Checks.notNull(publishFlowable, "Publish flowable");
+
         return publish(publishFlowable, PUBLISH_MAPPER);
     }
 
     public <P> @NotNull Flowable<Mqtt5PublishResult> publish(
-            final @Nullable Flowable<P> publishFlowable, final @NotNull Function<P, MqttPublish> publishMapper) {
-
-        Checks.notNull(publishFlowable, "Publish flowable");
+            final @NotNull Flowable<P> publishFlowable, final @NotNull Function<P, MqttPublish> publishMapper) {
 
         final Scheduler applicationScheduler = clientConfig.getExecutorConfig().getApplicationScheduler();
         if (publishFlowable instanceof ScalarCallable) {
@@ -177,13 +185,15 @@ public class MqttRxClient implements Mqtt5RxClient {
 
     @Override
     public @NotNull Completable disconnect(final @Nullable Mqtt5Disconnect disconnect) {
+        return disconnect(MqttChecks.disconnect(disconnect));
+    }
+
+    @NotNull Completable disconnect(final @NotNull MqttDisconnect disconnect) {
         return disconnectUnsafe(disconnect).observeOn(clientConfig.getExecutorConfig().getApplicationScheduler());
     }
 
-    @NotNull Completable disconnectUnsafe(final @Nullable Mqtt5Disconnect disconnect) {
-        final MqttDisconnect mqttDisconnect = MqttChecks.disconnect(disconnect);
-
-        return new MqttDisconnectCompletable(clientConfig, mqttDisconnect);
+    @NotNull Completable disconnectUnsafe(final @NotNull MqttDisconnect disconnect) {
+        return new MqttDisconnectCompletable(clientConfig, disconnect);
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttAckFlow.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttAckFlow.java
@@ -15,39 +15,26 @@
  *
  */
 
-package com.hivemq.client.internal.mqtt.handler.subscribe;
+package com.hivemq.client.internal.mqtt.handler.publish.outgoing;
 
+import com.hivemq.client.internal.annotations.CallByThread;
 import com.hivemq.client.internal.mqtt.MqttClientConfig;
 import com.hivemq.client.internal.mqtt.handler.util.FlowWithEventLoop;
-import io.reactivex.SingleObserver;
-import io.reactivex.disposables.Disposable;
+import com.hivemq.client.internal.mqtt.message.publish.MqttPublishResult;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * @author Silvio Giebl
  */
-class MqttSubOrUnsubAckFlow<T> extends FlowWithEventLoop implements MqttSubscriptionFlow<T>, Disposable {
+abstract class MqttAckFlow extends FlowWithEventLoop {
 
-    private final @NotNull SingleObserver<? super T> observer;
-
-    MqttSubOrUnsubAckFlow(
-            final @NotNull SingleObserver<? super T> observer, final @NotNull MqttClientConfig clientConfig) {
-
+    MqttAckFlow(final @NotNull MqttClientConfig clientConfig) {
         super(clientConfig);
-        this.observer = observer;
     }
 
-    @Override
-    public void onSuccess(final @NotNull T t) {
-        if (setDone()) {
-            observer.onSuccess(t);
-        }
-    }
+    @CallByThread("Netty EventLoop")
+    abstract void onNext(final @NotNull MqttPublishResult result);
 
-    @Override
-    public void onError(final @NotNull Throwable t) {
-        if (setDone()) {
-            observer.onError(t);
-        }
-    }
+    @CallByThread("Netty EventLoop")
+    abstract void acknowledged(final long acknowledged);
 }

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttAckFlowableFlow.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttAckFlowableFlow.java
@@ -20,7 +20,6 @@ package com.hivemq.client.internal.mqtt.handler.publish.outgoing;
 import com.hivemq.client.internal.annotations.CallByThread;
 import com.hivemq.client.internal.mqtt.MqttClientConfig;
 import com.hivemq.client.internal.mqtt.handler.publish.outgoing.MqttPublishFlowableAckLink.LinkCancellable;
-import com.hivemq.client.internal.mqtt.handler.util.FlowWithEventLoop;
 import com.hivemq.client.internal.mqtt.message.publish.MqttPublishResult;
 import com.hivemq.client.internal.util.collections.ChunkedArrayQueue;
 import io.reactivex.internal.util.BackpressureHelper;
@@ -37,7 +36,7 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * @author Silvio Giebl
  */
-public class MqttIncomingAckFlow extends FlowWithEventLoop implements Subscription, Runnable {
+class MqttAckFlowableFlow extends MqttAckFlow implements Subscription, Runnable {
 
     private static final int STATE_NO_NEW_REQUESTS = 0;
     private static final int STATE_NEW_REQUESTS = 1;
@@ -59,7 +58,7 @@ public class MqttIncomingAckFlow extends FlowWithEventLoop implements Subscripti
 
     private final @NotNull AtomicReference<@Nullable LinkCancellable> linkCancellable = new AtomicReference<>();
 
-    MqttIncomingAckFlow(
+    MqttAckFlowableFlow(
             final @NotNull Subscriber<? super MqttPublishResult> subscriber,
             final @NotNull MqttClientConfig clientConfig, final @NotNull MqttOutgoingQosHandler outgoingQosHandler) {
 
@@ -70,6 +69,7 @@ public class MqttIncomingAckFlow extends FlowWithEventLoop implements Subscripti
     }
 
     @CallByThread("Netty EventLoop")
+    @Override
     void onNext(final @NotNull MqttPublishResult result) {
         queue.offer(result);
         run();
@@ -113,6 +113,7 @@ public class MqttIncomingAckFlow extends FlowWithEventLoop implements Subscripti
     }
 
     @CallByThread("Netty EventLoop")
+    @Override
     void acknowledged(final long acknowledged) {
         if (acknowledged > 0) {
             final long acknowledgedLocal = this.acknowledgedNettyLocal += acknowledged;

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttAckSingleFlowable.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttAckSingleFlowable.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2018 dc-square and the HiveMQ MQTT Client Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hivemq.client.internal.mqtt.handler.publish.outgoing;
+
+import com.hivemq.client.internal.annotations.CallByThread;
+import com.hivemq.client.internal.mqtt.MqttClientConfig;
+import com.hivemq.client.internal.mqtt.exceptions.MqttClientStateExceptions;
+import com.hivemq.client.internal.mqtt.ioc.ClientComponent;
+import com.hivemq.client.internal.mqtt.message.publish.MqttPublish;
+import com.hivemq.client.internal.mqtt.message.publish.MqttPublishResult;
+import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5PublishResult;
+import io.reactivex.Flowable;
+import io.reactivex.internal.subscriptions.EmptySubscription;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Silvio Giebl
+ */
+public class MqttAckSingleFlowable extends Flowable<Mqtt5PublishResult> {
+
+    private final @NotNull MqttClientConfig clientConfig;
+    private final @NotNull MqttPublish publish;
+
+    public MqttAckSingleFlowable(final @NotNull MqttClientConfig clientConfig, final @NotNull MqttPublish publish) {
+        this.clientConfig = clientConfig;
+        this.publish = publish;
+    }
+
+    @Override
+    protected void subscribeActual(final @NotNull Subscriber<? super Mqtt5PublishResult> subscriber) {
+        if (clientConfig.getState().isConnectedOrReconnect()) {
+            final ClientComponent clientComponent = clientConfig.getClientComponent();
+            final MqttOutgoingQosHandler outgoingQosHandler = clientComponent.outgoingQosHandler();
+            final MqttPublishFlowables publishFlowables = outgoingQosHandler.getPublishFlowables();
+
+            final Flow flow = new Flow(subscriber, clientConfig, outgoingQosHandler);
+            subscriber.onSubscribe(flow);
+            publishFlowables.add(Flowable.just(new MqttPublishWithFlow(publish, flow)));
+        } else {
+            EmptySubscription.error(MqttClientStateExceptions.notConnected(), subscriber);
+        }
+    }
+
+    private static class Flow extends MqttAckFlow implements Subscription, Runnable {
+
+        private static final int STATE_NONE = 0;
+        private static final int STATE_RESULT = 1;
+        private static final int STATE_REQUESTED = 2;
+
+        private final @NotNull Subscriber<? super Mqtt5PublishResult> subscriber;
+        private final @NotNull MqttOutgoingQosHandler outgoingQosHandler;
+
+        private final @NotNull AtomicInteger state = new AtomicInteger(STATE_NONE);
+        private @Nullable MqttPublishResult result;
+
+        Flow(
+                final @NotNull Subscriber<? super Mqtt5PublishResult> subscriber,
+                final @NotNull MqttClientConfig clientConfig,
+                final @NotNull MqttOutgoingQosHandler outgoingQosHandler) {
+
+            super(clientConfig);
+            this.subscriber = subscriber;
+            this.outgoingQosHandler = outgoingQosHandler;
+            init();
+        }
+
+        @CallByThread("Netty EventLoop")
+        @Override
+        void onNext(final @NotNull MqttPublishResult result) {
+            if (state.get() == STATE_REQUESTED) {
+                onNextUnsafe(result);
+            } else {
+                this.result = result;
+                if (!state.compareAndSet(STATE_NONE, STATE_RESULT)) {
+                    this.result = null;
+                    onNextUnsafe(result);
+                } else if (isCancelled()) {
+                    this.result = null;
+                    if (result.acknowledged()) {
+                        acknowledged(1);
+                    }
+                }
+            }
+        }
+
+        @CallByThread("Netty EventLoop")
+        private void onNextUnsafe(final @NotNull MqttPublishResult result) {
+            subscriber.onNext(result);
+            if (result.acknowledged()) {
+                acknowledged(1);
+            }
+        }
+
+        @CallByThread("Netty EventLoop")
+        @Override
+        void acknowledged(final long acknowledged) {
+            if (acknowledged != 1) {
+                throw new IllegalStateException(
+                        "A single publish must be acknowledged exactly once. This must not happen and is a bug.");
+            }
+            if (setDone()) {
+                subscriber.onComplete();
+            }
+            outgoingQosHandler.request(1);
+        }
+
+        @Override
+        public void request(final long n) {
+            if ((n > 0) && !isCancelled() && (state.getAndSet(STATE_REQUESTED) == STATE_RESULT)) {
+                eventLoop.execute(this);
+            }
+        }
+
+        @Override
+        protected void onCancel() {
+            if (state.get() == STATE_RESULT) {
+                eventLoop.execute(this);
+            }
+        }
+
+        @CallByThread("Netty EventLoop")
+        @Override
+        public void run() {
+            final MqttPublishResult result = this.result;
+            if (result != null) {
+                this.result = null;
+                if (isCancelled()) {
+                    if (result.acknowledged()) {
+                        acknowledged(1);
+                    }
+                } else {
+                    onNextUnsafe(result);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttIncomingAckFlow.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttIncomingAckFlow.java
@@ -148,12 +148,6 @@ public class MqttIncomingAckFlow extends FlowWithEventLoop implements Subscripti
         }
     }
 
-    @CallByThread("Netty EventLoop")
-    void onError(final @NotNull Throwable t) {
-        error = t;
-        cancelLink(); // subscriber.onError called in onLinkCancelled
-    }
-
     @Override
     public void request(final long n) {
         if ((n > 0) && !isCancelled()) {
@@ -205,18 +199,6 @@ public class MqttIncomingAckFlow extends FlowWithEventLoop implements Subscripti
         final LinkCancellable linkCancellable = this.linkCancellable.getAndSet(LinkCancellable.CANCELLED);
         if (linkCancellable != null) {
             linkCancellable.cancelLink();
-        }
-    }
-
-    void onLinkCancelled() {
-        final Throwable error = this.error;
-        if (error != null) {
-            final long acknowledged = acknowledgedNettyLocal;
-            final long published = acknowledged + queue.size();
-            this.published.set(published);
-            if ((acknowledged == published) && setDone()) {
-                subscriber.onError(error);
-            }
         }
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttIncomingAckFlowable.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttIncomingAckFlowable.java
@@ -53,7 +53,6 @@ public class MqttIncomingAckFlowable extends Flowable<Mqtt5PublishResult> {
             final MqttIncomingAckFlow flow = new MqttIncomingAckFlow(subscriber, clientConfig, outgoingQosHandler);
             subscriber.onSubscribe(flow);
             if (publishFlowable instanceof ScalarCallable) {
-                flow.link(flow::onLinkCancelled); // TODO remove when individual publishes are errored
                 flow.onComplete(1); // TODO special subclasses of MqttIncomingAckFlow
                 //noinspection unchecked
                 publishFlowables.add(Flowable.just(

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttOutgoingQosHandler.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttOutgoingQosHandler.java
@@ -48,6 +48,7 @@ import com.hivemq.client.internal.util.collections.IntMap;
 import com.hivemq.client.internal.util.netty.ContextFuture;
 import com.hivemq.client.internal.util.netty.DefaultContextPromise;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.exceptions.ConnectionClosedException;
 import com.hivemq.client.mqtt.mqtt5.advanced.interceptor.qos1.Mqtt5OutgoingQos1Interceptor;
 import com.hivemq.client.mqtt.mqtt5.advanced.interceptor.qos2.Mqtt5OutgoingQos2Interceptor;
 import com.hivemq.client.mqtt.mqtt5.exceptions.Mqtt5PubAckException;
@@ -228,11 +229,14 @@ public class MqttOutgoingQosHandler extends MqttSessionAwareHandler
 
     @Override
     public void operationComplete(final @NotNull ContextFuture<? extends MqttPublishWithFlow> future) {
+        final MqttPublishWithFlow publishWithFlow = future.getContext();
+        final MqttPublish publish = publishWithFlow.getPublish();
+        final MqttIncomingAckFlow ackFlow = publishWithFlow.getIncomingAckFlow();
         final Throwable cause = future.cause();
         if (!(cause instanceof IOException)) {
-            final MqttPublishWithFlow publishWithFlow = future.getContext();
-            publishWithFlow.getIncomingAckFlow().onNext(new MqttPublishResult(publishWithFlow.getPublish(), cause));
+            ackFlow.onNext(new MqttPublishResult(publish, cause));
         } else {
+            ackFlow.onNext(new MqttPublishResult(publish, new ConnectionClosedException(cause)));
             future.channel().pipeline().fireExceptionCaught(cause);
         }
     }
@@ -405,7 +409,7 @@ public class MqttOutgoingQosHandler extends MqttSessionAwareHandler
             assert qos1Or2Map != null;
             final MqttPublishWithFlow publishWithFlow = (MqttPublishWithFlow) qos1Or2Map.remove(currentWrite);
             assert publishWithFlow != null;
-            publishWithFlow.getIncomingAckFlow().onError(cause);
+            publishWithFlow.getIncomingAckFlow().onNext(new MqttPublishResult(publishWithFlow.getPublish(), cause));
             removed(currentWrite);
             currentWrite = -1;
         } else {
@@ -428,9 +432,20 @@ public class MqttOutgoingQosHandler extends MqttSessionAwareHandler
                 packetIdentifiers.returnId(qos1Or2PacketId);
                 final MqttPubOrRelWithFlow removed = qos1Or2Map.remove(qos1Or2PacketId);
                 assert removed != null;
-                removed.getIncomingAckFlow().onError(cause);
+
+                if (removed instanceof MqttPublishWithFlow) {
+                    final MqttPublishWithFlow publishWithFlow = (MqttPublishWithFlow) removed;
+                    removed.getIncomingAckFlow().onNext(new MqttPublishResult(publishWithFlow.getPublish(), cause));
+                } else if (QOS_2_COMPLETE_RESULT) {
+                    final MqttQos2CompleteWithFlow publishWithFlow = (MqttQos2CompleteWithFlow) removed;
+                    removed.getIncomingAckFlow().onNext(new MqttPublishResult(publishWithFlow.getPublish(), cause));
+                } else {
+                    final MqttQos2IntermediateWithFlow intermediate = (MqttQos2IntermediateWithFlow) removed;
+                    if (intermediate.getAsBoolean()) {
+                        intermediate.getIncomingAckFlow().acknowledged(1);
+                    }
+                }
             }
-            request(pending);
         }
 
         clearQueued(cause);
@@ -441,9 +456,6 @@ public class MqttOutgoingQosHandler extends MqttSessionAwareHandler
         while (true) {
             final MqttPublishWithFlow publishWithFlow = queue.poll();
             if (publishWithFlow == null) {
-                if (polled > 0) {
-                    request(polled);
-                }
                 if (queuedCounter.addAndGet(-polled) == 0) {
                     break;
                 } else {
@@ -451,7 +463,7 @@ public class MqttOutgoingQosHandler extends MqttSessionAwareHandler
                     continue;
                 }
             }
-            publishWithFlow.getIncomingAckFlow().onError(cause);
+            publishWithFlow.getIncomingAckFlow().onNext(new MqttPublishResult(publishWithFlow.getPublish(), cause));
             polled++;
         }
     }

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttPubOrRelWithFlow.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttPubOrRelWithFlow.java
@@ -24,13 +24,13 @@ import org.jetbrains.annotations.NotNull;
  */
 abstract class MqttPubOrRelWithFlow {
 
-    private final @NotNull MqttIncomingAckFlow ackFlow;
+    private final @NotNull MqttAckFlow ackFlow;
 
-    MqttPubOrRelWithFlow(final @NotNull MqttIncomingAckFlow ackFlow) {
+    MqttPubOrRelWithFlow(final @NotNull MqttAckFlow ackFlow) {
         this.ackFlow = ackFlow;
     }
 
-    @NotNull MqttIncomingAckFlow getIncomingAckFlow() {
+    @NotNull MqttAckFlow getAckFlow() {
         return ackFlow;
     }
 }

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttPubRelWithFlow.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttPubRelWithFlow.java
@@ -31,8 +31,8 @@ abstract class MqttPubRelWithFlow extends MqttPubOrRelWithFlow {
 
     private final @NotNull MqttPubRel pubRel;
 
-    MqttPubRelWithFlow(final @NotNull MqttPubRel pubRel, final @NotNull MqttIncomingAckFlow incomingAckFlow) {
-        super(incomingAckFlow);
+    MqttPubRelWithFlow(final @NotNull MqttPubRel pubRel, final @NotNull MqttAckFlow ackFlow) {
+        super(ackFlow);
         this.pubRel = pubRel;
     }
 
@@ -45,9 +45,9 @@ abstract class MqttPubRelWithFlow extends MqttPubOrRelWithFlow {
         private int state;
 
         MqttQos2IntermediateWithFlow(
-                final @NotNull MqttPubRel pubRel, final @NotNull MqttIncomingAckFlow incomingAckFlow) {
+                final @NotNull MqttPubRel pubRel, final @NotNull MqttAckFlow ackFlow) {
 
-            super(pubRel, incomingAckFlow);
+            super(pubRel, ackFlow);
         }
 
         @Override
@@ -63,9 +63,9 @@ abstract class MqttPubRelWithFlow extends MqttPubOrRelWithFlow {
 
         MqttQos2CompleteWithFlow(
                 final @NotNull MqttPublish publish, final @NotNull MqttPubRec pubRec, final @NotNull MqttPubRel pubRel,
-                final @NotNull MqttIncomingAckFlow incomingAckFlow) {
+                final @NotNull MqttAckFlow ackFlow) {
 
-            super(pubRel, incomingAckFlow);
+            super(pubRel, ackFlow);
             this.publish = publish;
             this.pubRec = pubRec;
         }

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttPublishFlowableAckLink.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttPublishFlowableAckLink.java
@@ -33,10 +33,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class MqttPublishFlowableAckLink extends Flowable<MqttPublishWithFlow> {
 
     private final @NotNull Flowable<MqttPublish> source;
-    private final @NotNull MqttIncomingAckFlow ackFlow;
+    private final @NotNull MqttAckFlowableFlow ackFlow;
 
     MqttPublishFlowableAckLink(
-            final @NotNull Flowable<MqttPublish> source, final @NotNull MqttIncomingAckFlow ackFlow) {
+            final @NotNull Flowable<MqttPublish> source, final @NotNull MqttAckFlowableFlow ackFlow) {
 
         this.source = source;
         this.ackFlow = ackFlow;
@@ -64,7 +64,7 @@ public class MqttPublishFlowableAckLink extends Flowable<MqttPublishWithFlow> {
         static final int STATE_CANCEL = 3;
         static final int STATE_CANCELLED = 4;
 
-        private final @NotNull MqttIncomingAckFlow ackFlow;
+        private final @NotNull MqttAckFlowableFlow ackFlow;
         private boolean linked;
         private final @NotNull AtomicInteger state = new AtomicInteger();
         private final @NotNull AtomicInteger pollState = new AtomicInteger();
@@ -73,7 +73,7 @@ public class MqttPublishFlowableAckLink extends Flowable<MqttPublishWithFlow> {
 
         AckLinkSubscriber(
                 final @NotNull Subscriber<? super MqttPublishWithFlow> subscriber,
-                final @NotNull MqttIncomingAckFlow ackFlow) {
+                final @NotNull MqttAckFlowableFlow ackFlow) {
 
             super(subscriber);
             this.ackFlow = ackFlow;

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttPublishFlowableAckLink.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttPublishFlowableAckLink.java
@@ -197,8 +197,6 @@ public class MqttPublishFlowableAckLink extends Flowable<MqttPublishWithFlow> {
             final int previousState = state.getAndSet(STATE_CANCEL);
             if ((previousState == STATE_NONE) && (pollState.getAndSet(STATE_CANCEL) == STATE_NONE)) {
                 cancelActual();
-            } else if ((previousState == STATE_DONE) && state.compareAndSet(STATE_CANCEL, STATE_CANCELLED)) {
-                ackFlow.onLinkCancelled();
             }
         }
 
@@ -209,7 +207,6 @@ public class MqttPublishFlowableAckLink extends Flowable<MqttPublishWithFlow> {
                 if (sourceMode != SYNC) {
                     subscriber.onComplete();
                 }
-                ackFlow.onLinkCancelled();
             }
         }
     }

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttPublishFlowableAckLink.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttPublishFlowableAckLink.java
@@ -169,10 +169,11 @@ public class MqttPublishFlowableAckLink extends Flowable<MqttPublishWithFlow> {
                     }
                 } else { // ASYNC
                     if (state.get() == STATE_DONE) {
+                        final Throwable error = this.error;
                         if (error == null) {
                             ackFlow.onComplete(published);
                         } else {
-                            ackFlow.onError(error);
+                            ackFlow.onError(error, published);
                         }
                     }
                     stopEmitting(pollState);

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttPublishWithFlow.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttPublishWithFlow.java
@@ -27,8 +27,8 @@ class MqttPublishWithFlow extends MqttPubOrRelWithFlow {
 
     private final @NotNull MqttPublish publish;
 
-    MqttPublishWithFlow(final @NotNull MqttPublish publish, final @NotNull MqttIncomingAckFlow incomingAckFlow) {
-        super(incomingAckFlow);
+    MqttPublishWithFlow(final @NotNull MqttPublish publish, final @NotNull MqttAckFlow ackFlow) {
+        super(ackFlow);
         this.publish = publish;
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/util/FlowWithEventLoop.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/util/FlowWithEventLoop.java
@@ -65,6 +65,10 @@ public abstract class FlowWithEventLoop {
         }
     }
 
+    public void dispose() {
+        cancel();
+    }
+
     protected void onCancel() {}
 
     public boolean isCancelled() {

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/publish/MqttPublishResult.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/publish/MqttPublishResult.java
@@ -52,6 +52,10 @@ public class MqttPublishResult implements Mqtt5PublishResult {
         return Optional.ofNullable(error);
     }
 
+    public @Nullable Throwable getRawError() {
+        return error;
+    }
+
     public boolean acknowledged() {
         return true;
     }

--- a/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3AsyncClientView.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3AsyncClientView.java
@@ -18,11 +18,15 @@
 package com.hivemq.client.internal.mqtt.mqtt3;
 
 import com.hivemq.client.internal.mqtt.MqttAsyncClient;
+import com.hivemq.client.internal.mqtt.message.connect.MqttConnect;
 import com.hivemq.client.internal.mqtt.message.connect.connack.mqtt3.Mqtt3ConnAckView;
 import com.hivemq.client.internal.mqtt.message.disconnect.mqtt3.Mqtt3DisconnectView;
+import com.hivemq.client.internal.mqtt.message.publish.MqttPublish;
 import com.hivemq.client.internal.mqtt.message.publish.mqtt3.Mqtt3PublishView;
+import com.hivemq.client.internal.mqtt.message.subscribe.MqttSubscribe;
 import com.hivemq.client.internal.mqtt.message.subscribe.mqtt3.Mqtt3SubscribeViewBuilder;
 import com.hivemq.client.internal.mqtt.message.subscribe.suback.mqtt3.Mqtt3SubAckView;
+import com.hivemq.client.internal.mqtt.message.unsubscribe.MqttUnsubscribe;
 import com.hivemq.client.internal.mqtt.mqtt3.exceptions.Mqtt3ExceptionFactory;
 import com.hivemq.client.internal.mqtt.util.MqttChecks;
 import com.hivemq.client.internal.util.Checks;
@@ -107,21 +111,26 @@ public class Mqtt3AsyncClientView implements Mqtt3AsyncClient {
 
     @Override
     public @NotNull CompletableFuture<@NotNull Mqtt3ConnAck> connect(final @Nullable Mqtt3Connect connect) {
-        return delegate.connect(MqttChecks.connect(connect)).handle(CONNACK_MAPPER);
+        final MqttConnect mqttConnect = MqttChecks.connect(connect);
+
+        return delegate.connect(mqttConnect).handle(CONNACK_MAPPER);
     }
 
     @Override
     public @NotNull CompletableFuture<@NotNull Mqtt3SubAck> subscribe(final @Nullable Mqtt3Subscribe subscribe) {
-        return delegate.subscribe(MqttChecks.subscribe(subscribe)).handle(SUBACK_MAPPER);
+        final MqttSubscribe mqttSubscribe = MqttChecks.subscribe(subscribe);
+
+        return delegate.subscribe(mqttSubscribe).handle(SUBACK_MAPPER);
     }
 
     @Override
     public @NotNull CompletableFuture<@NotNull Mqtt3SubAck> subscribe(
             final @Nullable Mqtt3Subscribe subscribe, final @Nullable Consumer<@NotNull Mqtt3Publish> callback) {
 
+        final MqttSubscribe mqttSubscribe = MqttChecks.subscribe(subscribe);
         Checks.notNull(callback, "Callback");
 
-        return delegate.subscribe(MqttChecks.subscribe(subscribe), callbackView(callback)).handle(SUBACK_MAPPER);
+        return delegate.subscribe(mqttSubscribe, callbackView(callback)).handle(SUBACK_MAPPER);
     }
 
     @Override
@@ -129,17 +138,18 @@ public class Mqtt3AsyncClientView implements Mqtt3AsyncClient {
             final @Nullable Mqtt3Subscribe subscribe, final @Nullable Consumer<@NotNull Mqtt3Publish> callback,
             final @Nullable Executor executor) {
 
+        final MqttSubscribe mqttSubscribe = MqttChecks.subscribe(subscribe);
         Checks.notNull(callback, "Callback");
         Checks.notNull(executor, "Executor");
 
-        return delegate.subscribe(MqttChecks.subscribe(subscribe), callbackView(callback), executor)
-                .handle(SUBACK_MAPPER);
+        return delegate.subscribe(mqttSubscribe, callbackView(callback), executor).handle(SUBACK_MAPPER);
     }
 
     @Override
     public void publishes(
             final @Nullable MqttGlobalPublishFilter filter, final @Nullable Consumer<@NotNull Mqtt3Publish> callback) {
 
+        Checks.notNull(filter, "Global publish filter");
         Checks.notNull(callback, "Callback");
 
         delegate.publishes(filter, callbackView(callback));
@@ -150,6 +160,7 @@ public class Mqtt3AsyncClientView implements Mqtt3AsyncClient {
             final @Nullable MqttGlobalPublishFilter filter, final @Nullable Consumer<@NotNull Mqtt3Publish> callback,
             final @Nullable Executor executor) {
 
+        Checks.notNull(filter, "Global publish filter");
         Checks.notNull(callback, "Callback");
         Checks.notNull(executor, "Executor");
 
@@ -158,12 +169,16 @@ public class Mqtt3AsyncClientView implements Mqtt3AsyncClient {
 
     @Override
     public @NotNull CompletableFuture<Void> unsubscribe(final @Nullable Mqtt3Unsubscribe unsubscribe) {
-        return delegate.unsubscribe(MqttChecks.unsubscribe(unsubscribe)).handle(UNSUBACK_MAPPER);
+        final MqttUnsubscribe mqttUnsubscribe = MqttChecks.unsubscribe(unsubscribe);
+
+        return delegate.unsubscribe(mqttUnsubscribe).handle(UNSUBACK_MAPPER);
     }
 
     @Override
     public @NotNull CompletableFuture<@NotNull Mqtt3Publish> publish(final @Nullable Mqtt3Publish publish) {
-        return delegate.publish(MqttChecks.publish(publish)).handle(PUBLISH_RESULT_MAPPER);
+        final MqttPublish mqttPublish = MqttChecks.publish(publish);
+
+        return delegate.publish(mqttPublish).handle(PUBLISH_RESULT_MAPPER);
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3BlockingClientView.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3BlockingClientView.java
@@ -18,10 +18,14 @@
 package com.hivemq.client.internal.mqtt.mqtt3;
 
 import com.hivemq.client.internal.mqtt.MqttBlockingClient;
+import com.hivemq.client.internal.mqtt.message.connect.MqttConnect;
 import com.hivemq.client.internal.mqtt.message.connect.connack.mqtt3.Mqtt3ConnAckView;
 import com.hivemq.client.internal.mqtt.message.disconnect.mqtt3.Mqtt3DisconnectView;
+import com.hivemq.client.internal.mqtt.message.publish.MqttPublish;
 import com.hivemq.client.internal.mqtt.message.publish.mqtt3.Mqtt3PublishView;
+import com.hivemq.client.internal.mqtt.message.subscribe.MqttSubscribe;
 import com.hivemq.client.internal.mqtt.message.subscribe.suback.mqtt3.Mqtt3SubAckView;
+import com.hivemq.client.internal.mqtt.message.unsubscribe.MqttUnsubscribe;
 import com.hivemq.client.internal.mqtt.mqtt3.exceptions.Mqtt3ExceptionFactory;
 import com.hivemq.client.internal.mqtt.util.MqttChecks;
 import com.hivemq.client.internal.util.AsyncRuntimeException;
@@ -60,8 +64,9 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
 
     @Override
     public @NotNull Mqtt3ConnAck connect(final @Nullable Mqtt3Connect connect) {
+        final MqttConnect mqttConnect = MqttChecks.connect(connect);
         try {
-            return Mqtt3ConnAckView.of(delegate.connect(MqttChecks.connect(connect)));
+            return Mqtt3ConnAckView.of(delegate.connect(mqttConnect));
         } catch (final Mqtt5MessageException e) {
             throw AsyncRuntimeException.fillInStackTrace(Mqtt3ExceptionFactory.map(e));
         }
@@ -69,8 +74,9 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
 
     @Override
     public @NotNull Mqtt3SubAck subscribe(final @Nullable Mqtt3Subscribe subscribe) {
+        final MqttSubscribe mqttSubscribe = MqttChecks.subscribe(subscribe);
         try {
-            return Mqtt3SubAckView.of(delegate.subscribe(MqttChecks.subscribe(subscribe)));
+            return Mqtt3SubAckView.of(delegate.subscribe(mqttSubscribe));
         } catch (final Mqtt5MessageException e) {
             throw AsyncRuntimeException.fillInStackTrace(Mqtt3ExceptionFactory.map(e));
         }
@@ -78,13 +84,16 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
 
     @Override
     public @NotNull Mqtt3Publishes publishes(final @Nullable MqttGlobalPublishFilter filter) {
+        Checks.notNull(filter, "Global publish filter");
+
         return new Mqtt3PublishesView(delegate.publishes(filter));
     }
 
     @Override
     public void unsubscribe(final @Nullable Mqtt3Unsubscribe unsubscribe) {
+        final MqttUnsubscribe mqttUnsubscribe = MqttChecks.unsubscribe(unsubscribe);
         try {
-            delegate.unsubscribe(MqttChecks.unsubscribe(unsubscribe));
+            delegate.unsubscribe(mqttUnsubscribe);
         } catch (final Mqtt5MessageException e) {
             throw AsyncRuntimeException.fillInStackTrace(Mqtt3ExceptionFactory.map(e));
         }
@@ -92,8 +101,9 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
 
     @Override
     public void publish(final @Nullable Mqtt3Publish publish) {
+        final MqttPublish mqttPublish = MqttChecks.publish(publish);
         try {
-            delegate.publish(MqttChecks.publish(publish));
+            delegate.publish(mqttPublish);
         } catch (final Mqtt5MessageException e) {
             throw AsyncRuntimeException.fillInStackTrace(Mqtt3ExceptionFactory.map(e));
         }

--- a/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3RxClientView.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3RxClientView.java
@@ -26,7 +26,6 @@ import com.hivemq.client.internal.mqtt.message.publish.mqtt3.Mqtt3PublishView;
 import com.hivemq.client.internal.mqtt.message.subscribe.suback.mqtt3.Mqtt3SubAckView;
 import com.hivemq.client.internal.mqtt.mqtt3.exceptions.Mqtt3ExceptionFactory;
 import com.hivemq.client.internal.mqtt.util.MqttChecks;
-import com.hivemq.client.internal.util.Checks;
 import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
 import com.hivemq.client.mqtt.mqtt3.Mqtt3RxClient;
 import com.hivemq.client.mqtt.mqtt3.message.connect.Mqtt3Connect;
@@ -45,7 +44,6 @@ import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.fuseable.ScalarCallable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -118,13 +116,7 @@ public class Mqtt3RxClientView implements Mqtt3RxClient {
 
     @Override
     public @NotNull Flowable<Mqtt3PublishResult> publish(final @Nullable Flowable<Mqtt3Publish> publishFlowable) {
-        Checks.notNull(publishFlowable, "Publish flowable");
-        if (publishFlowable instanceof ScalarCallable) {
-            return delegate.publishHalfSafe(publishFlowable.map(PUBLISH_MAPPER))
-                    .onErrorResumeNext(EXCEPTION_MAPPER_FLOWABLE_PUBLISH_RESULT)
-                    .map(Mqtt3PublishResultView.MAPPER); // TODO
-        }
-        return delegate.publish(publishFlowable.map(PUBLISH_MAPPER))
+        return delegate.publish(publishFlowable, PUBLISH_MAPPER)
                 .onErrorResumeNext(EXCEPTION_MAPPER_FLOWABLE_PUBLISH_RESULT)
                 .map(Mqtt3PublishResultView.MAPPER);
     }

--- a/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3RxClientView.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3RxClientView.java
@@ -18,14 +18,18 @@
 package com.hivemq.client.internal.mqtt.mqtt3;
 
 import com.hivemq.client.internal.mqtt.MqttRxClient;
+import com.hivemq.client.internal.mqtt.message.connect.MqttConnect;
 import com.hivemq.client.internal.mqtt.message.connect.connack.mqtt3.Mqtt3ConnAckView;
 import com.hivemq.client.internal.mqtt.message.disconnect.mqtt3.Mqtt3DisconnectView;
 import com.hivemq.client.internal.mqtt.message.publish.MqttPublish;
 import com.hivemq.client.internal.mqtt.message.publish.mqtt3.Mqtt3PublishResultView;
 import com.hivemq.client.internal.mqtt.message.publish.mqtt3.Mqtt3PublishView;
+import com.hivemq.client.internal.mqtt.message.subscribe.MqttSubscribe;
 import com.hivemq.client.internal.mqtt.message.subscribe.suback.mqtt3.Mqtt3SubAckView;
+import com.hivemq.client.internal.mqtt.message.unsubscribe.MqttUnsubscribe;
 import com.hivemq.client.internal.mqtt.mqtt3.exceptions.Mqtt3ExceptionFactory;
 import com.hivemq.client.internal.mqtt.util.MqttChecks;
+import com.hivemq.client.internal.util.Checks;
 import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
 import com.hivemq.client.mqtt.mqtt3.Mqtt3RxClient;
 import com.hivemq.client.mqtt.mqtt3.message.connect.Mqtt3Connect;
@@ -80,14 +84,18 @@ public class Mqtt3RxClientView implements Mqtt3RxClient {
 
     @Override
     public @NotNull Single<Mqtt3ConnAck> connect(final @Nullable Mqtt3Connect connect) {
-        return delegate.connect(MqttChecks.connect(connect))
+        final MqttConnect mqttConnect = MqttChecks.connect(connect);
+
+        return delegate.connect(mqttConnect)
                 .onErrorResumeNext(EXCEPTION_MAPPER_SINGLE_CONNACK)
                 .map(Mqtt3ConnAckView.MAPPER);
     }
 
     @Override
     public @NotNull Single<Mqtt3SubAck> subscribe(final @Nullable Mqtt3Subscribe subscribe) {
-        return delegate.subscribe(MqttChecks.subscribe(subscribe))
+        final MqttSubscribe mqttSubscribe = MqttChecks.subscribe(subscribe);
+
+        return delegate.subscribe(mqttSubscribe)
                 .onErrorResumeNext(EXCEPTION_MAPPER_SINGLE_SUBACK)
                 .map(Mqtt3SubAckView.MAPPER);
     }
@@ -96,13 +104,17 @@ public class Mqtt3RxClientView implements Mqtt3RxClient {
     public @NotNull FlowableWithSingle<Mqtt3Publish, Mqtt3SubAck> subscribeStream(
             final @Nullable Mqtt3Subscribe subscribe) {
 
-        return delegate.subscribeStream(MqttChecks.subscribe(subscribe))
+        final MqttSubscribe mqttSubscribe = MqttChecks.subscribe(subscribe);
+
+        return delegate.subscribeStream(mqttSubscribe)
                 .mapError(Mqtt3ExceptionFactory.MAPPER)
                 .mapBoth(Mqtt3PublishView.MAPPER, Mqtt3SubAckView.MAPPER);
     }
 
     @Override
     public @NotNull Flowable<Mqtt3Publish> publishes(final @Nullable MqttGlobalPublishFilter filter) {
+        Checks.notNull(filter, "Global publish filter");
+
         return delegate.publishes(filter)
                 .onErrorResumeNext(EXCEPTION_MAPPER_FLOWABLE_PUBLISH)
                 .map(Mqtt3PublishView.MAPPER);
@@ -110,12 +122,15 @@ public class Mqtt3RxClientView implements Mqtt3RxClient {
 
     @Override
     public @NotNull Completable unsubscribe(final @Nullable Mqtt3Unsubscribe unsubscribe) {
-        return delegate.unsubscribe(MqttChecks.unsubscribe(unsubscribe)).ignoreElement()
-                .onErrorResumeNext(EXCEPTION_MAPPER_COMPLETABLE);
+        final MqttUnsubscribe mqttUnsubscribe = MqttChecks.unsubscribe(unsubscribe);
+
+        return delegate.unsubscribe(mqttUnsubscribe).ignoreElement().onErrorResumeNext(EXCEPTION_MAPPER_COMPLETABLE);
     }
 
     @Override
     public @NotNull Flowable<Mqtt3PublishResult> publish(final @Nullable Flowable<Mqtt3Publish> publishFlowable) {
+        Checks.notNull(publishFlowable, "Publish flowable");
+
         return delegate.publish(publishFlowable, PUBLISH_MAPPER)
                 .onErrorResumeNext(EXCEPTION_MAPPER_FLOWABLE_PUBLISH_RESULT)
                 .map(Mqtt3PublishResultView.MAPPER);

--- a/src/test/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3RxClientViewExceptionsTest.java
+++ b/src/test/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3RxClientViewExceptionsTest.java
@@ -123,7 +123,7 @@ class Mqtt3RxClientViewExceptionsTest {
     void publish() {
         final Mqtt5MessageException mqtt5MessageException =
                 new Mqtt5DisconnectException(MqttDisconnect.DEFAULT, "reason from original exception");
-        given(mqtt5Client.publish(any())).willReturn(Flowable.error(mqtt5MessageException));
+        given(mqtt5Client.publish(any(), any())).willReturn(Flowable.error(mqtt5MessageException));
 
         final Flowable<Mqtt3Publish> publish =
                 Flowable.just(Mqtt3Publish.builder().topic("topic").qos(MqttQos.AT_LEAST_ONCE).build());


### PR DESCRIPTION
**Motivation**
Resolves #283 

**Changes**
- AsyncClient: fixed publish ordering, this also has the effect of lower overhead per publish for Async/BlockingClient
- RxClient: Error individual publishes instead of the flow (expected behaviour, cancelling may devour messages)