### PR TITLE
Update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
+dist: trusty
+
 language: java
 
 jdk:
-  - openjdk8
-  - openjdk9
+  - oraclejdk8
+  - oraclejdk9
 
 stages:
   - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,11 @@ addons:
   apt:
     packages:
       - perl
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: java
 
 jdk:
-  - oraclejdk8
-  - oraclejdk9
+  - openjdk8
+  - openjdk9
 
 stages:
   - test
-  #- name: snapshot
-  #  if: branch = develop && type != pull_request
   - name: release
     if: branch = master && type != pull_request
 
@@ -15,9 +13,6 @@ script: ./gradlew check javadoc
 
 jobs:
   include:
-    #- stage: snapshot
-    #  install: true
-    #  script: ./gradlew artifactoryPublish -x test -Dsnapshot=true
     - stage: release
       install: true
       script: ./gradlew bintrayUpload -x test


### PR DESCRIPTION
**Motivation**
Travis CI switched the default dist from trusty to xenial.
On xenial oraclejdk8 is no longer supported.

**Changes**
- Set dist explicitely to trusty
- Additional: added gradle caching