### PR TITLE
Removed wrong call to RxJavaPlugins.onError if PublishFlow.onError is called for multiple subscriptions

### DIFF
--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/incoming/MqttIncomingPublishFlow.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/incoming/MqttIncomingPublishFlow.java
@@ -92,7 +92,9 @@ public abstract class MqttIncomingPublishFlow extends FlowWithEventLoop
     @Override
     public void onError(final @NotNull Throwable t) {
         if (done) {
-            RxJavaPlugins.onError(t);
+            if (t != error) {
+                RxJavaPlugins.onError(t);
+            }
             return;
         }
         error = t;


### PR DESCRIPTION
**Motivation**
Resolves #295 

**Changes**
- Removed wrong call to RxJavaPlugins.onError if PublishFlow.onError is called for multiple subscriptions