### PR TITLE
Nested Mqtt5Exceptions are now mapped to Mqtt3Exceptions

### DIFF
--- a/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3BlockingClientView.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3BlockingClientView.java
@@ -145,7 +145,7 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
         public @NotNull Mqtt3Publish receive() throws InterruptedException {
             try {
                 return Mqtt3PublishView.of(delegate.receive());
-            } catch (final Mqtt5MessageException e) {
+            } catch (final RuntimeException e) {
                 throw AsyncRuntimeException.fillInStackTrace(Mqtt3ExceptionFactory.map(e));
             }
         }
@@ -161,7 +161,7 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
 
             try {
                 return delegate.receive(timeout, timeUnit).map(Mqtt3PublishView.JAVA_MAPPER);
-            } catch (final Mqtt5MessageException e) {
+            } catch (final RuntimeException e) {
                 throw AsyncRuntimeException.fillInStackTrace(Mqtt3ExceptionFactory.map(e));
             }
         }
@@ -170,7 +170,7 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
         public @NotNull Optional<Mqtt3Publish> receiveNow() {
             try {
                 return delegate.receiveNow().map(Mqtt3PublishView.JAVA_MAPPER);
-            } catch (final Mqtt5MessageException e) {
+            } catch (final RuntimeException e) {
                 throw AsyncRuntimeException.fillInStackTrace(Mqtt3ExceptionFactory.map(e));
             }
         }

--- a/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3BlockingClientView.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3BlockingClientView.java
@@ -28,7 +28,6 @@ import com.hivemq.client.internal.mqtt.message.subscribe.suback.mqtt3.Mqtt3SubAc
 import com.hivemq.client.internal.mqtt.message.unsubscribe.MqttUnsubscribe;
 import com.hivemq.client.internal.mqtt.mqtt3.exceptions.Mqtt3ExceptionFactory;
 import com.hivemq.client.internal.mqtt.util.MqttChecks;
-import com.hivemq.client.internal.util.AsyncRuntimeException;
 import com.hivemq.client.internal.util.Checks;
 import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
 import com.hivemq.client.mqtt.mqtt3.Mqtt3AsyncClient;
@@ -68,7 +67,7 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
         try {
             return Mqtt3ConnAckView.of(delegate.connect(mqttConnect));
         } catch (final Mqtt5MessageException e) {
-            throw AsyncRuntimeException.fillInStackTrace(Mqtt3ExceptionFactory.map(e));
+            throw Mqtt3ExceptionFactory.mapWithStackTrace(e);
         }
     }
 
@@ -78,7 +77,7 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
         try {
             return Mqtt3SubAckView.of(delegate.subscribe(mqttSubscribe));
         } catch (final Mqtt5MessageException e) {
-            throw AsyncRuntimeException.fillInStackTrace(Mqtt3ExceptionFactory.map(e));
+            throw Mqtt3ExceptionFactory.mapWithStackTrace(e);
         }
     }
 
@@ -95,7 +94,7 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
         try {
             delegate.unsubscribe(mqttUnsubscribe);
         } catch (final Mqtt5MessageException e) {
-            throw AsyncRuntimeException.fillInStackTrace(Mqtt3ExceptionFactory.map(e));
+            throw Mqtt3ExceptionFactory.mapWithStackTrace(e);
         }
     }
 
@@ -105,7 +104,7 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
         try {
             delegate.publish(mqttPublish);
         } catch (final Mqtt5MessageException e) {
-            throw AsyncRuntimeException.fillInStackTrace(Mqtt3ExceptionFactory.map(e));
+            throw Mqtt3ExceptionFactory.mapWithStackTrace(e);
         }
     }
 
@@ -114,7 +113,7 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
         try {
             delegate.disconnect(Mqtt3DisconnectView.DELEGATE);
         } catch (final Mqtt5MessageException e) {
-            throw AsyncRuntimeException.fillInStackTrace(Mqtt3ExceptionFactory.map(e));
+            throw Mqtt3ExceptionFactory.mapWithStackTrace(e);
         }
     }
 
@@ -146,7 +145,7 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
             try {
                 return Mqtt3PublishView.of(delegate.receive());
             } catch (final RuntimeException e) {
-                throw AsyncRuntimeException.fillInStackTrace(Mqtt3ExceptionFactory.map(e));
+                throw Mqtt3ExceptionFactory.mapWithStackTrace(e);
             }
         }
 
@@ -162,7 +161,7 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
             try {
                 return delegate.receive(timeout, timeUnit).map(Mqtt3PublishView.JAVA_MAPPER);
             } catch (final RuntimeException e) {
-                throw AsyncRuntimeException.fillInStackTrace(Mqtt3ExceptionFactory.map(e));
+                throw Mqtt3ExceptionFactory.mapWithStackTrace(e);
             }
         }
 
@@ -171,7 +170,7 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
             try {
                 return delegate.receiveNow().map(Mqtt3PublishView.JAVA_MAPPER);
             } catch (final RuntimeException e) {
-                throw AsyncRuntimeException.fillInStackTrace(Mqtt3ExceptionFactory.map(e));
+                throw Mqtt3ExceptionFactory.mapWithStackTrace(e);
             }
         }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/exceptions/Mqtt3ExceptionFactory.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/exceptions/Mqtt3ExceptionFactory.java
@@ -57,6 +57,14 @@ public final class Mqtt3ExceptionFactory {
         return e;
     }
 
+    public static @NotNull RuntimeException mapWithStackTrace(final @NotNull RuntimeException e) {
+        final RuntimeException mapped = map(e);
+        if (mapped != e) {
+            mapped.setStackTrace(e.getStackTrace());
+        }
+        return mapped;
+    }
+
     public static @NotNull Mqtt3MessageException map(final @NotNull Mqtt5MessageException mqtt5MessageException) {
         final Mqtt5Message mqttMessage = mqtt5MessageException.getMqttMessage();
         final String message = mqtt5MessageException.getMessage();

--- a/src/main/java/com/hivemq/client/internal/util/AsyncRuntimeException.java
+++ b/src/main/java/com/hivemq/client/internal/util/AsyncRuntimeException.java
@@ -20,6 +20,8 @@ package com.hivemq.client.internal.util;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Arrays;
+
 /**
  * @author Silvio Giebl
  */
@@ -27,38 +29,36 @@ public abstract class AsyncRuntimeException extends RuntimeException {
 
     public static @NotNull RuntimeException fillInStackTrace(final @NotNull RuntimeException e) {
         if (e instanceof AsyncRuntimeException) {
-            e.fillInStackTrace();
+            final AsyncRuntimeException copy = ((AsyncRuntimeException) e).copy().superFillInStackTrace();
+            final StackTraceElement[] stackTrace = copy.getStackTrace();
+            // remove the sync and superFillInStackTrace method calls from the trace
+            copy.setStackTrace(Arrays.copyOfRange(stackTrace, 2, stackTrace.length));
+            return copy;
         }
         return e;
     }
 
-    private final boolean afterSuper;
-
-    protected AsyncRuntimeException() {
-        super();
-        afterSuper = true;
-    }
-
     protected AsyncRuntimeException(final @Nullable String message) {
         super(message, null);
-        afterSuper = true;
     }
 
     protected AsyncRuntimeException(final @Nullable String message, final @Nullable Throwable cause) {
         super(message, cause);
-        afterSuper = true;
     }
 
     protected AsyncRuntimeException(final @Nullable Throwable cause) {
         super(cause);
-        afterSuper = true;
     }
 
     @Override
     public synchronized @NotNull Throwable fillInStackTrace() {
-        if (afterSuper) {
-            return super.fillInStackTrace();
-        }
         return this;
     }
+
+    private @NotNull AsyncRuntimeException superFillInStackTrace() {
+        super.fillInStackTrace();
+        return this;
+    }
+
+    protected abstract @NotNull AsyncRuntimeException copy();
 }

--- a/src/main/java/com/hivemq/client/mqtt/exceptions/ConnectionClosedException.java
+++ b/src/main/java/com/hivemq/client/mqtt/exceptions/ConnectionClosedException.java
@@ -19,7 +19,6 @@ package com.hivemq.client.mqtt.exceptions;
 
 import com.hivemq.client.internal.util.AsyncRuntimeException;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Exception that is used if a MQTT connection is closed without a Disconnect message.
@@ -37,12 +36,12 @@ public class ConnectionClosedException extends AsyncRuntimeException {
         super(cause);
     }
 
-    private ConnectionClosedException(final @Nullable String message, final @Nullable Throwable cause) {
-        super(message, cause);
+    private ConnectionClosedException(final @NotNull ConnectionClosedException e) {
+        super(e);
     }
 
     @Override
     protected @NotNull ConnectionClosedException copy() {
-        return new ConnectionClosedException(getMessage(), getCause());
+        return new ConnectionClosedException(this);
     }
 }

--- a/src/main/java/com/hivemq/client/mqtt/exceptions/ConnectionClosedException.java
+++ b/src/main/java/com/hivemq/client/mqtt/exceptions/ConnectionClosedException.java
@@ -19,6 +19,7 @@ package com.hivemq.client.mqtt.exceptions;
 
 import com.hivemq.client.internal.util.AsyncRuntimeException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Exception that is used if a MQTT connection is closed without a Disconnect message.
@@ -34,5 +35,14 @@ public class ConnectionClosedException extends AsyncRuntimeException {
 
     public ConnectionClosedException(final @NotNull Throwable cause) {
         super(cause);
+    }
+
+    private ConnectionClosedException(final @Nullable String message, final @Nullable Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    protected @NotNull ConnectionClosedException copy() {
+        return new ConnectionClosedException(getMessage(), getCause());
     }
 }

--- a/src/main/java/com/hivemq/client/mqtt/exceptions/ConnectionFailedException.java
+++ b/src/main/java/com/hivemq/client/mqtt/exceptions/ConnectionFailedException.java
@@ -19,6 +19,7 @@ package com.hivemq.client.mqtt.exceptions;
 
 import com.hivemq.client.internal.util.AsyncRuntimeException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Exception that is used if a MQTT connection could not be established.
@@ -34,5 +35,14 @@ public class ConnectionFailedException extends AsyncRuntimeException {
 
     public ConnectionFailedException(final @NotNull Throwable cause) {
         super(cause);
+    }
+
+    private ConnectionFailedException(final @Nullable String message, final @Nullable Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    protected @NotNull ConnectionFailedException copy() {
+        return new ConnectionFailedException(getMessage(), getCause());
     }
 }

--- a/src/main/java/com/hivemq/client/mqtt/exceptions/ConnectionFailedException.java
+++ b/src/main/java/com/hivemq/client/mqtt/exceptions/ConnectionFailedException.java
@@ -19,7 +19,6 @@ package com.hivemq.client.mqtt.exceptions;
 
 import com.hivemq.client.internal.util.AsyncRuntimeException;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Exception that is used if a MQTT connection could not be established.
@@ -37,12 +36,12 @@ public class ConnectionFailedException extends AsyncRuntimeException {
         super(cause);
     }
 
-    private ConnectionFailedException(final @Nullable String message, final @Nullable Throwable cause) {
-        super(message, cause);
+    private ConnectionFailedException(final @NotNull ConnectionFailedException e) {
+        super(e);
     }
 
     @Override
     protected @NotNull ConnectionFailedException copy() {
-        return new ConnectionFailedException(getMessage(), getCause());
+        return new ConnectionFailedException(this);
     }
 }

--- a/src/main/java/com/hivemq/client/mqtt/exceptions/MqttClientStateException.java
+++ b/src/main/java/com/hivemq/client/mqtt/exceptions/MqttClientStateException.java
@@ -33,8 +33,12 @@ public class MqttClientStateException extends AsyncRuntimeException {
         super(message);
     }
 
+    private MqttClientStateException(final @NotNull MqttClientStateException e) {
+        super(e);
+    }
+
     @Override
     protected @NotNull MqttClientStateException copy() {
-        return new MqttClientStateException(getMessage());
+        return new MqttClientStateException(this);
     }
 }

--- a/src/main/java/com/hivemq/client/mqtt/exceptions/MqttClientStateException.java
+++ b/src/main/java/com/hivemq/client/mqtt/exceptions/MqttClientStateException.java
@@ -32,4 +32,9 @@ public class MqttClientStateException extends AsyncRuntimeException {
     public MqttClientStateException(final @NotNull String message) {
         super(message);
     }
+
+    @Override
+    protected @NotNull MqttClientStateException copy() {
+        return new MqttClientStateException(getMessage());
+    }
 }

--- a/src/main/java/com/hivemq/client/mqtt/exceptions/MqttDecodeException.java
+++ b/src/main/java/com/hivemq/client/mqtt/exceptions/MqttDecodeException.java
@@ -32,8 +32,12 @@ public class MqttDecodeException extends AsyncRuntimeException {
         super(message);
     }
 
+    private MqttDecodeException(final @NotNull MqttDecodeException e) {
+        super(e);
+    }
+
     @Override
     protected @NotNull MqttDecodeException copy() {
-        return new MqttDecodeException(getMessage());
+        return new MqttDecodeException(this);
     }
 }

--- a/src/main/java/com/hivemq/client/mqtt/exceptions/MqttDecodeException.java
+++ b/src/main/java/com/hivemq/client/mqtt/exceptions/MqttDecodeException.java
@@ -31,4 +31,9 @@ public class MqttDecodeException extends AsyncRuntimeException {
     public MqttDecodeException(final @NotNull String message) {
         super(message);
     }
+
+    @Override
+    protected @NotNull MqttDecodeException copy() {
+        return new MqttDecodeException(getMessage());
+    }
 }

--- a/src/main/java/com/hivemq/client/mqtt/exceptions/MqttEncodeException.java
+++ b/src/main/java/com/hivemq/client/mqtt/exceptions/MqttEncodeException.java
@@ -31,4 +31,9 @@ public class MqttEncodeException extends AsyncRuntimeException {
     public MqttEncodeException(final @NotNull String message) {
         super(message);
     }
+
+    @Override
+    protected @NotNull MqttEncodeException copy() {
+        return new MqttEncodeException(getMessage());
+    }
 }

--- a/src/main/java/com/hivemq/client/mqtt/exceptions/MqttEncodeException.java
+++ b/src/main/java/com/hivemq/client/mqtt/exceptions/MqttEncodeException.java
@@ -32,8 +32,12 @@ public class MqttEncodeException extends AsyncRuntimeException {
         super(message);
     }
 
+    private MqttEncodeException(final @NotNull MqttEncodeException e) {
+        super(e);
+    }
+
     @Override
     protected @NotNull MqttEncodeException copy() {
-        return new MqttEncodeException(getMessage());
+        return new MqttEncodeException(this);
     }
 }

--- a/src/main/java/com/hivemq/client/mqtt/exceptions/MqttSessionExpiredException.java
+++ b/src/main/java/com/hivemq/client/mqtt/exceptions/MqttSessionExpiredException.java
@@ -31,4 +31,9 @@ public class MqttSessionExpiredException extends AsyncRuntimeException {
     public MqttSessionExpiredException(final @NotNull String message, final @NotNull Throwable cause) {
         super(message, cause);
     }
+
+    @Override
+    protected @NotNull MqttSessionExpiredException copy() {
+        return new MqttSessionExpiredException(getMessage(), getCause());
+    }
 }

--- a/src/main/java/com/hivemq/client/mqtt/exceptions/MqttSessionExpiredException.java
+++ b/src/main/java/com/hivemq/client/mqtt/exceptions/MqttSessionExpiredException.java
@@ -32,8 +32,12 @@ public class MqttSessionExpiredException extends AsyncRuntimeException {
         super(message, cause);
     }
 
+    private MqttSessionExpiredException(final @NotNull MqttSessionExpiredException e) {
+        super(e);
+    }
+
     @Override
     protected @NotNull MqttSessionExpiredException copy() {
-        return new MqttSessionExpiredException(getMessage(), getCause());
+        return new MqttSessionExpiredException(this);
     }
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3ConnAckException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3ConnAckException.java
@@ -37,6 +37,11 @@ public class Mqtt3ConnAckException extends Mqtt3MessageException {
     }
 
     @Override
+    protected @NotNull Mqtt3ConnAckException copy() {
+        return new Mqtt3ConnAckException(connAck, getMessage(), getCause());
+    }
+
+    @Override
     public @NotNull Mqtt3ConnAck getMqttMessage() {
         return connAck;
     }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3ConnAckException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3ConnAckException.java
@@ -36,9 +36,14 @@ public class Mqtt3ConnAckException extends Mqtt3MessageException {
         this.connAck = connAck;
     }
 
+    private Mqtt3ConnAckException(final @NotNull Mqtt3ConnAckException e) {
+        super(e);
+        connAck = e.connAck;
+    }
+
     @Override
     protected @NotNull Mqtt3ConnAckException copy() {
-        return new Mqtt3ConnAckException(connAck, getMessage(), getCause());
+        return new Mqtt3ConnAckException(this);
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3DisconnectException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3DisconnectException.java
@@ -32,9 +32,13 @@ public class Mqtt3DisconnectException extends Mqtt3MessageException {
         super(message, cause);
     }
 
+    private Mqtt3DisconnectException(final @NotNull Mqtt3DisconnectException e) {
+        super(e);
+    }
+
     @Override
     protected @NotNull Mqtt3DisconnectException copy() {
-        return new Mqtt3DisconnectException(getMessage(), getCause());
+        return new Mqtt3DisconnectException(this);
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3DisconnectException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3DisconnectException.java
@@ -33,6 +33,11 @@ public class Mqtt3DisconnectException extends Mqtt3MessageException {
     }
 
     @Override
+    protected @NotNull Mqtt3DisconnectException copy() {
+        return new Mqtt3DisconnectException(getMessage(), getCause());
+    }
+
+    @Override
     public @NotNull Mqtt3Disconnect getMqttMessage() {
         return Mqtt3DisconnectView.INSTANCE;
     }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3MessageException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3MessageException.java
@@ -33,5 +33,9 @@ public abstract class Mqtt3MessageException extends AsyncRuntimeException {
         super(message, cause);
     }
 
+    Mqtt3MessageException(final @NotNull Mqtt3MessageException e) {
+        super(e);
+    }
+
     public abstract @NotNull Mqtt3Message getMqttMessage();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3PubAckException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3PubAckException.java
@@ -33,6 +33,11 @@ public class Mqtt3PubAckException extends Mqtt3MessageException {
     }
 
     @Override
+    protected @NotNull Mqtt3PubAckException copy() {
+        return new Mqtt3PubAckException(getMessage(), getCause());
+    }
+
+    @Override
     public @NotNull Mqtt3PubAck getMqttMessage() {
         return Mqtt3PubAckView.INSTANCE;
     }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3PubAckException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3PubAckException.java
@@ -32,9 +32,13 @@ public class Mqtt3PubAckException extends Mqtt3MessageException {
         super(message, cause);
     }
 
+    private Mqtt3PubAckException(final @NotNull Mqtt3PubAckException e) {
+        super(e);
+    }
+
     @Override
     protected @NotNull Mqtt3PubAckException copy() {
-        return new Mqtt3PubAckException(getMessage(), getCause());
+        return new Mqtt3PubAckException(this);
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3PubRecException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3PubRecException.java
@@ -33,6 +33,11 @@ public class Mqtt3PubRecException extends Mqtt3MessageException {
     }
 
     @Override
+    protected @NotNull Mqtt3PubRecException copy() {
+        return new Mqtt3PubRecException(getMessage(), getCause());
+    }
+
+    @Override
     public @NotNull Mqtt3PubRec getMqttMessage() {
         return Mqtt3PubRecView.INSTANCE;
     }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3PubRecException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3PubRecException.java
@@ -32,9 +32,13 @@ public class Mqtt3PubRecException extends Mqtt3MessageException {
         super(message, cause);
     }
 
+    private Mqtt3PubRecException(final @NotNull Mqtt3PubRecException e) {
+        super(e);
+    }
+
     @Override
     protected @NotNull Mqtt3PubRecException copy() {
-        return new Mqtt3PubRecException(getMessage(), getCause());
+        return new Mqtt3PubRecException(this);
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3SubAckException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3SubAckException.java
@@ -36,9 +36,14 @@ public class Mqtt3SubAckException extends Mqtt3MessageException {
         this.subAck = subAck;
     }
 
+    private Mqtt3SubAckException(final @NotNull Mqtt3SubAckException e) {
+        super(e);
+        subAck = e.subAck;
+    }
+
     @Override
     protected @NotNull Mqtt3SubAckException copy() {
-        return new Mqtt3SubAckException(subAck, getMessage(), getCause());
+        return new Mqtt3SubAckException(this);
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3SubAckException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3SubAckException.java
@@ -37,6 +37,11 @@ public class Mqtt3SubAckException extends Mqtt3MessageException {
     }
 
     @Override
+    protected @NotNull Mqtt3SubAckException copy() {
+        return new Mqtt3SubAckException(subAck, getMessage(), getCause());
+    }
+
+    @Override
     public @NotNull Mqtt3SubAck getMqttMessage() {
         return subAck;
     }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3UnsubAckException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3UnsubAckException.java
@@ -33,6 +33,11 @@ public class Mqtt3UnsubAckException extends Mqtt3MessageException {
     }
 
     @Override
+    protected @NotNull Mqtt3UnsubAckException copy() {
+        return new Mqtt3UnsubAckException(getMessage(), getCause());
+    }
+
+    @Override
     public @NotNull Mqtt3UnsubAck getMqttMessage() {
         return Mqtt3UnsubAckView.INSTANCE;
     }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3UnsubAckException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/exceptions/Mqtt3UnsubAckException.java
@@ -32,9 +32,13 @@ public class Mqtt3UnsubAckException extends Mqtt3MessageException {
         super(message, cause);
     }
 
+    private Mqtt3UnsubAckException(final @NotNull Mqtt3UnsubAckException e) {
+        super(e);
+    }
+
     @Override
     protected @NotNull Mqtt3UnsubAckException copy() {
-        return new Mqtt3UnsubAckException(getMessage(), getCause());
+        return new Mqtt3UnsubAckException(this);
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5AuthException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5AuthException.java
@@ -19,6 +19,7 @@ package com.hivemq.client.mqtt.mqtt5.exceptions;
 
 import com.hivemq.client.mqtt.mqtt5.message.auth.Mqtt5Auth;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Silvio Giebl
@@ -31,6 +32,18 @@ public class Mqtt5AuthException extends Mqtt5MessageException {
     public Mqtt5AuthException(final @NotNull Mqtt5Auth auth, final @NotNull String message) {
         super(message);
         this.auth = auth;
+    }
+
+    private Mqtt5AuthException(
+            final @NotNull Mqtt5Auth auth, final @Nullable String message, final @Nullable Throwable cause) {
+
+        super(message, cause);
+        this.auth = auth;
+    }
+
+    @Override
+    protected @NotNull Mqtt5AuthException copy() {
+        return new Mqtt5AuthException(auth, getMessage(), getCause());
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5AuthException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5AuthException.java
@@ -19,7 +19,6 @@ package com.hivemq.client.mqtt.mqtt5.exceptions;
 
 import com.hivemq.client.mqtt.mqtt5.message.auth.Mqtt5Auth;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Silvio Giebl
@@ -34,16 +33,14 @@ public class Mqtt5AuthException extends Mqtt5MessageException {
         this.auth = auth;
     }
 
-    private Mqtt5AuthException(
-            final @NotNull Mqtt5Auth auth, final @Nullable String message, final @Nullable Throwable cause) {
-
-        super(message, cause);
-        this.auth = auth;
+    private Mqtt5AuthException(final @NotNull Mqtt5AuthException e) {
+        super(e);
+        auth = e.auth;
     }
 
     @Override
     protected @NotNull Mqtt5AuthException copy() {
-        return new Mqtt5AuthException(auth, getMessage(), getCause());
+        return new Mqtt5AuthException(this);
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5ConnAckException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5ConnAckException.java
@@ -19,6 +19,7 @@ package com.hivemq.client.mqtt.mqtt5.exceptions;
 
 import com.hivemq.client.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAck;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Silvio Giebl
@@ -31,6 +32,18 @@ public class Mqtt5ConnAckException extends Mqtt5MessageException {
     public Mqtt5ConnAckException(final @NotNull Mqtt5ConnAck connAck, final @NotNull String message) {
         super(message);
         this.connAck = connAck;
+    }
+
+    private Mqtt5ConnAckException(
+            final @NotNull Mqtt5ConnAck connAck, final @Nullable String message, final @Nullable Throwable cause) {
+
+        super(message, cause);
+        this.connAck = connAck;
+    }
+
+    @Override
+    protected @NotNull Mqtt5ConnAckException copy() {
+        return new Mqtt5ConnAckException(connAck, getMessage(), getCause());
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5ConnAckException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5ConnAckException.java
@@ -19,7 +19,6 @@ package com.hivemq.client.mqtt.mqtt5.exceptions;
 
 import com.hivemq.client.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAck;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Silvio Giebl
@@ -34,16 +33,14 @@ public class Mqtt5ConnAckException extends Mqtt5MessageException {
         this.connAck = connAck;
     }
 
-    private Mqtt5ConnAckException(
-            final @NotNull Mqtt5ConnAck connAck, final @Nullable String message, final @Nullable Throwable cause) {
-
-        super(message, cause);
-        this.connAck = connAck;
+    private Mqtt5ConnAckException(final @NotNull Mqtt5ConnAckException e) {
+        super(e);
+        connAck = e.connAck;
     }
 
     @Override
     protected @NotNull Mqtt5ConnAckException copy() {
-        return new Mqtt5ConnAckException(connAck, getMessage(), getCause());
+        return new Mqtt5ConnAckException(this);
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5DisconnectException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5DisconnectException.java
@@ -19,6 +19,7 @@ package com.hivemq.client.mqtt.mqtt5.exceptions;
 
 import com.hivemq.client.mqtt.mqtt5.message.disconnect.Mqtt5Disconnect;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Silvio Giebl
@@ -36,6 +37,19 @@ public class Mqtt5DisconnectException extends Mqtt5MessageException {
     public Mqtt5DisconnectException(final @NotNull Mqtt5Disconnect disconnect, final @NotNull Throwable cause) {
         super(cause);
         this.disconnect = disconnect;
+    }
+
+    private Mqtt5DisconnectException(
+            final @NotNull Mqtt5Disconnect disconnect, final @Nullable String message,
+            final @Nullable Throwable cause) {
+
+        super(message, cause);
+        this.disconnect = disconnect;
+    }
+
+    @Override
+    protected @NotNull Mqtt5DisconnectException copy() {
+        return new Mqtt5DisconnectException(disconnect, getMessage(), getCause());
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5DisconnectException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5DisconnectException.java
@@ -19,7 +19,6 @@ package com.hivemq.client.mqtt.mqtt5.exceptions;
 
 import com.hivemq.client.mqtt.mqtt5.message.disconnect.Mqtt5Disconnect;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Silvio Giebl
@@ -39,17 +38,14 @@ public class Mqtt5DisconnectException extends Mqtt5MessageException {
         this.disconnect = disconnect;
     }
 
-    private Mqtt5DisconnectException(
-            final @NotNull Mqtt5Disconnect disconnect, final @Nullable String message,
-            final @Nullable Throwable cause) {
-
-        super(message, cause);
-        this.disconnect = disconnect;
+    private Mqtt5DisconnectException(final @NotNull Mqtt5DisconnectException e) {
+        super(e);
+        disconnect = e.disconnect;
     }
 
     @Override
     protected @NotNull Mqtt5DisconnectException copy() {
-        return new Mqtt5DisconnectException(disconnect, getMessage(), getCause());
+        return new Mqtt5DisconnectException(this);
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5MessageException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5MessageException.java
@@ -20,7 +20,6 @@ package com.hivemq.client.mqtt.mqtt5.exceptions;
 import com.hivemq.client.internal.util.AsyncRuntimeException;
 import com.hivemq.client.mqtt.mqtt5.message.Mqtt5Message;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Silvio Giebl
@@ -36,8 +35,8 @@ public abstract class Mqtt5MessageException extends AsyncRuntimeException {
         super(cause.getMessage(), cause);
     }
 
-    Mqtt5MessageException(final @Nullable String message, final @Nullable Throwable cause) {
-        super(message, cause);
+    Mqtt5MessageException(final @NotNull Mqtt5MessageException e) {
+        super(e);
     }
 
     public abstract @NotNull Mqtt5Message getMqttMessage();

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5MessageException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5MessageException.java
@@ -20,6 +20,7 @@ package com.hivemq.client.mqtt.mqtt5.exceptions;
 import com.hivemq.client.internal.util.AsyncRuntimeException;
 import com.hivemq.client.mqtt.mqtt5.message.Mqtt5Message;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Silvio Giebl
@@ -33,6 +34,10 @@ public abstract class Mqtt5MessageException extends AsyncRuntimeException {
 
     Mqtt5MessageException(final @NotNull Throwable cause) {
         super(cause.getMessage(), cause);
+    }
+
+    Mqtt5MessageException(final @Nullable String message, final @Nullable Throwable cause) {
+        super(message, cause);
     }
 
     public abstract @NotNull Mqtt5Message getMqttMessage();

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5PubAckException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5PubAckException.java
@@ -19,7 +19,6 @@ package com.hivemq.client.mqtt.mqtt5.exceptions;
 
 import com.hivemq.client.mqtt.mqtt5.message.publish.puback.Mqtt5PubAck;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Silvio Giebl
@@ -34,16 +33,14 @@ public class Mqtt5PubAckException extends Mqtt5MessageException {
         this.pubAck = pubAck;
     }
 
-    private Mqtt5PubAckException(
-            final @NotNull Mqtt5PubAck pubAck, final @Nullable String message, final @Nullable Throwable cause) {
-
-        super(message, cause);
-        this.pubAck = pubAck;
+    private Mqtt5PubAckException(final @NotNull Mqtt5PubAckException e) {
+        super(e);
+        pubAck = e.pubAck;
     }
 
     @Override
     protected @NotNull Mqtt5PubAckException copy() {
-        return new Mqtt5PubAckException(pubAck, getMessage(), getCause());
+        return new Mqtt5PubAckException(this);
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5PubAckException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5PubAckException.java
@@ -19,6 +19,7 @@ package com.hivemq.client.mqtt.mqtt5.exceptions;
 
 import com.hivemq.client.mqtt.mqtt5.message.publish.puback.Mqtt5PubAck;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Silvio Giebl
@@ -31,6 +32,18 @@ public class Mqtt5PubAckException extends Mqtt5MessageException {
     public Mqtt5PubAckException(final @NotNull Mqtt5PubAck pubAck, final @NotNull String message) {
         super(message);
         this.pubAck = pubAck;
+    }
+
+    private Mqtt5PubAckException(
+            final @NotNull Mqtt5PubAck pubAck, final @Nullable String message, final @Nullable Throwable cause) {
+
+        super(message, cause);
+        this.pubAck = pubAck;
+    }
+
+    @Override
+    protected @NotNull Mqtt5PubAckException copy() {
+        return new Mqtt5PubAckException(pubAck, getMessage(), getCause());
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5PubRecException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5PubRecException.java
@@ -19,7 +19,6 @@ package com.hivemq.client.mqtt.mqtt5.exceptions;
 
 import com.hivemq.client.mqtt.mqtt5.message.publish.pubrec.Mqtt5PubRec;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Silvio Giebl
@@ -34,16 +33,14 @@ public class Mqtt5PubRecException extends Mqtt5MessageException {
         this.pubRec = pubRec;
     }
 
-    private Mqtt5PubRecException(
-            final @NotNull Mqtt5PubRec pubRec, final @Nullable String message, final @Nullable Throwable cause) {
-
-        super(message, cause);
-        this.pubRec = pubRec;
+    private Mqtt5PubRecException(final @NotNull Mqtt5PubRecException e) {
+        super(e);
+        pubRec = e.pubRec;
     }
 
     @Override
     protected @NotNull Mqtt5PubRecException copy() {
-        return new Mqtt5PubRecException(pubRec, getMessage(), getCause());
+        return new Mqtt5PubRecException(this);
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5PubRecException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5PubRecException.java
@@ -19,6 +19,7 @@ package com.hivemq.client.mqtt.mqtt5.exceptions;
 
 import com.hivemq.client.mqtt.mqtt5.message.publish.pubrec.Mqtt5PubRec;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Silvio Giebl
@@ -31,6 +32,18 @@ public class Mqtt5PubRecException extends Mqtt5MessageException {
     public Mqtt5PubRecException(final @NotNull Mqtt5PubRec pubRec, final @NotNull String message) {
         super(message);
         this.pubRec = pubRec;
+    }
+
+    private Mqtt5PubRecException(
+            final @NotNull Mqtt5PubRec pubRec, final @Nullable String message, final @Nullable Throwable cause) {
+
+        super(message, cause);
+        this.pubRec = pubRec;
+    }
+
+    @Override
+    protected @NotNull Mqtt5PubRecException copy() {
+        return new Mqtt5PubRecException(pubRec, getMessage(), getCause());
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5SubAckException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5SubAckException.java
@@ -19,6 +19,7 @@ package com.hivemq.client.mqtt.mqtt5.exceptions;
 
 import com.hivemq.client.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAck;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Silvio Giebl
@@ -31,6 +32,18 @@ public class Mqtt5SubAckException extends Mqtt5MessageException {
     public Mqtt5SubAckException(final @NotNull Mqtt5SubAck subAck, final @NotNull String message) {
         super(message);
         this.subAck = subAck;
+    }
+
+    private Mqtt5SubAckException(
+            final @NotNull Mqtt5SubAck subAck, final @Nullable String message, final @Nullable Throwable cause) {
+
+        super(message, cause);
+        this.subAck = subAck;
+    }
+
+    @Override
+    protected @NotNull Mqtt5SubAckException copy() {
+        return new Mqtt5SubAckException(subAck, getMessage(), getCause());
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5SubAckException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5SubAckException.java
@@ -19,7 +19,6 @@ package com.hivemq.client.mqtt.mqtt5.exceptions;
 
 import com.hivemq.client.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAck;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Silvio Giebl
@@ -34,16 +33,14 @@ public class Mqtt5SubAckException extends Mqtt5MessageException {
         this.subAck = subAck;
     }
 
-    private Mqtt5SubAckException(
-            final @NotNull Mqtt5SubAck subAck, final @Nullable String message, final @Nullable Throwable cause) {
-
-        super(message, cause);
-        this.subAck = subAck;
+    private Mqtt5SubAckException(final @NotNull Mqtt5SubAckException e) {
+        super(e);
+        subAck = e.subAck;
     }
 
     @Override
     protected @NotNull Mqtt5SubAckException copy() {
-        return new Mqtt5SubAckException(subAck, getMessage(), getCause());
+        return new Mqtt5SubAckException(this);
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5UnsubAckException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5UnsubAckException.java
@@ -19,6 +19,7 @@ package com.hivemq.client.mqtt.mqtt5.exceptions;
 
 import com.hivemq.client.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAck;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Silvio Giebl
@@ -31,6 +32,18 @@ public class Mqtt5UnsubAckException extends Mqtt5MessageException {
     public Mqtt5UnsubAckException(final @NotNull Mqtt5UnsubAck unsubAck, final @NotNull String message) {
         super(message);
         this.unsubAck = unsubAck;
+    }
+
+    private Mqtt5UnsubAckException(
+            final @NotNull Mqtt5UnsubAck unsubAck, final @Nullable String message, final @Nullable Throwable cause) {
+
+        super(message, cause);
+        this.unsubAck = unsubAck;
+    }
+
+    @Override
+    protected @NotNull Mqtt5UnsubAckException copy() {
+        return new Mqtt5UnsubAckException(unsubAck, getMessage(), getCause());
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5UnsubAckException.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/exceptions/Mqtt5UnsubAckException.java
@@ -19,7 +19,6 @@ package com.hivemq.client.mqtt.mqtt5.exceptions;
 
 import com.hivemq.client.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAck;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Silvio Giebl
@@ -34,16 +33,14 @@ public class Mqtt5UnsubAckException extends Mqtt5MessageException {
         this.unsubAck = unsubAck;
     }
 
-    private Mqtt5UnsubAckException(
-            final @NotNull Mqtt5UnsubAck unsubAck, final @Nullable String message, final @Nullable Throwable cause) {
-
-        super(message, cause);
-        this.unsubAck = unsubAck;
+    private Mqtt5UnsubAckException(final @NotNull Mqtt5UnsubAckException e) {
+        super(e);
+        unsubAck = e.unsubAck;
     }
 
     @Override
     protected @NotNull Mqtt5UnsubAckException copy() {
-        return new Mqtt5UnsubAckException(unsubAck, getMessage(), getCause());
+        return new Mqtt5UnsubAckException(this);
     }
 
     @Override


### PR DESCRIPTION
**Motivation**
- `Mqtt5Exception`s are contained in strack traces of MQTT 3 clients, if they are the cause of a `MqttSessionExpiredException`.
- `MqttPublish.receive(Now)` does not throw if called after client was disconnected.

**Changes**
- Nested `Mqtt5Exception`s are now mapped to `Mqtt3Exception`s
- Fixed `MqttPublish.receive(Now)` not throwing exception if called after client was disconnected
- Fixed multiple calls to `AsyncRuntimeException.fillInStackTrace`, exception is now copied