### PR TITLE
Feature/sni

### DIFF
--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/MqttChannelInitializer.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/MqttChannelInitializer.java
@@ -119,7 +119,7 @@ public class MqttChannelInitializer extends ChannelInitializer<Channel> {
     private void initSsl(final @NotNull Channel channel, final @NotNull MqttClientSslConfigImpl sslConfig)
             throws SSLException {
 
-        SslUtil.initChannel(channel, sslConfig);
+        SslUtil.initChannel(channel, sslConfig, clientConfig.getServerHost(), clientConfig.getServerPort());
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/ssl/SslUtil.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/ssl/SslUtil.java
@@ -63,7 +63,6 @@ public final class SslUtil {
         return new DelegatingSslContext(sslContextBuilder.build()) {
             @Override
             protected void initEngine(@NotNull final SSLEngine engine) {
-                engine.setUseClientMode(true);
             }
 
             @Override

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/ssl/SslUtil.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/ssl/SslUtil.java
@@ -33,19 +33,20 @@ public final class SslUtil {
 
     private static final @NotNull String SSL_HANDLER_NAME = "ssl";
 
-    public static void initChannel(final @NotNull Channel channel, final @NotNull MqttClientSslConfigImpl sslConfig)
-            throws SSLException {
+    public static void initChannel(
+            final @NotNull Channel channel, final @NotNull MqttClientSslConfigImpl sslConfig,
+            final @NotNull String host, final int port) throws SSLException {
 
-        channel.pipeline().addFirst(SSL_HANDLER_NAME, createSslHandler(channel, sslConfig));
+        channel.pipeline().addFirst(SSL_HANDLER_NAME, createSslHandler(channel, sslConfig, host, port));
     }
 
     private static @NotNull SslHandler createSslHandler(
-            final @NotNull Channel channel, final @NotNull MqttClientSslConfigImpl sslConfig) throws SSLException {
-        return createSslContext(sslConfig).newHandler(channel.alloc());
+            final @NotNull Channel channel, final @NotNull MqttClientSslConfigImpl sslConfig,
+            final @NotNull String host, final int port) throws SSLException {
+        return createSslContext(sslConfig).newHandler(channel.alloc(), host, port);
     }
 
-    static @NotNull SslContext createSslContext(final @NotNull MqttClientSslConfigImpl sslConfig)
-            throws SSLException {
+    static @NotNull SslContext createSslContext(final @NotNull MqttClientSslConfigImpl sslConfig) throws SSLException {
 
         final SslContextBuilder sslContextBuilder = SslContextBuilder.forClient()
                 .sslProvider(SslProvider.JDK)

--- a/src/test/java/com/hivemq/client/internal/mqtt/handler/ssl/SslUtilTest.java
+++ b/src/test/java/com/hivemq/client/internal/mqtt/handler/ssl/SslUtilTest.java
@@ -19,6 +19,9 @@ package com.hivemq.client.internal.mqtt.handler.ssl;
 import com.hivemq.client.internal.mqtt.MqttClientSslConfigImplBuilder;
 import com.hivemq.client.internal.util.collections.ImmutableList;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.ssl.JdkSslClientContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
@@ -161,10 +164,11 @@ public class SslUtilTest {
     }
 
     private List<String> getEnabledCipherSuites() throws Exception {
-        final SSLContext context = SSLContext.getInstance("TLS");
-        context.init(null, null, null);
-        final SSLEngine sslEngine = context.createSSLEngine();
-        return Arrays.asList(sslEngine.getEnabledCipherSuites());
+        return Arrays.asList(SslContextBuilder.forClient()
+                .sslProvider(SslProvider.JDK)
+                .build()
+                .newEngine(new EmbeddedChannel().alloc())
+                .getEnabledCipherSuites());
     }
 
     private List<String> getEnabledProtocols() throws Exception {

--- a/src/test/java/com/hivemq/client/internal/mqtt/handler/ssl/SslUtilTest.java
+++ b/src/test/java/com/hivemq/client/internal/mqtt/handler/ssl/SslUtilTest.java
@@ -16,10 +16,11 @@
 
 package com.hivemq.client.internal.mqtt.handler.ssl;
 
+import com.hivemq.client.internal.mqtt.MqttClientSslConfigImpl;
 import com.hivemq.client.internal.mqtt.MqttClientSslConfigImplBuilder;
 import com.hivemq.client.internal.util.collections.ImmutableList;
+import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.ssl.JdkSslClientContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import org.jetbrains.annotations.NotNull;
@@ -28,6 +29,7 @@ import org.junit.Test;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -53,7 +55,7 @@ public class SslUtilTest {
 
         final TrustManagerFactory tmf = null;
 
-        final SSLEngine sslEngine = SslUtil.createSslEngine(embeddedChannel,
+        final SSLEngine sslEngine = createSslEngine(embeddedChannel,
                 new MqttClientSslConfigImplBuilder.Default().trustManagerFactory(tmf).build());
 
         assertNotNull(sslEngine);
@@ -69,7 +71,7 @@ public class SslUtilTest {
 
         final ImmutableList<String> cipherSuite = getFirstSupportedCipherSuite();
 
-        final SSLEngine sslEngine = SslUtil.createSslEngine(embeddedChannel,
+        final SSLEngine sslEngine = createSslEngine(embeddedChannel,
                 new MqttClientSslConfigImplBuilder.Default().trustManagerFactory(tmf)
                         .cipherSuites(cipherSuite)
                         .build());
@@ -89,7 +91,7 @@ public class SslUtilTest {
 
         final ImmutableList<String> cipherSuites = getOtherSupportedCipherSuites();
 
-        final SSLEngine sslEngine = SslUtil.createSslEngine(embeddedChannel,
+        final SSLEngine sslEngine = createSslEngine(embeddedChannel,
                 new MqttClientSslConfigImplBuilder.Default().trustManagerFactory(tmf)
                         .cipherSuites(cipherSuites)
                         .build());
@@ -112,7 +114,7 @@ public class SslUtilTest {
 
         final ImmutableList<String> protocol = ImmutableList.of("TLSv1");
 
-        final SSLEngine sslEngine = SslUtil.createSslEngine(embeddedChannel,
+        final SSLEngine sslEngine = createSslEngine(embeddedChannel,
                 new MqttClientSslConfigImplBuilder.Default().trustManagerFactory(tmf).protocols(protocol).build());
 
         assertNotNull(sslEngine);
@@ -130,7 +132,7 @@ public class SslUtilTest {
 
         final ImmutableList<String> protocols = ImmutableList.of("TLSv1.1", "TLSv1.2");
 
-        final SSLEngine sslEngine = SslUtil.createSslEngine(embeddedChannel,
+        final SSLEngine sslEngine = createSslEngine(embeddedChannel,
                 new MqttClientSslConfigImplBuilder.Default().trustManagerFactory(tmf).protocols(protocols).build());
 
         assertNotNull(sslEngine);
@@ -176,5 +178,11 @@ public class SslUtilTest {
         context.init(null, null, null);
         final SSLEngine sslEngine = context.createSSLEngine();
         return Arrays.asList(sslEngine.getEnabledProtocols());
+    }
+
+    static @NotNull SSLEngine createSslEngine(
+            final @NotNull Channel channel, final @NotNull MqttClientSslConfigImpl sslConfig) throws SSLException {
+
+        return SslUtil.createSslContext(sslConfig).newEngine(channel.alloc());
     }
 }


### PR DESCRIPTION
**Motivation**
Multiple domains can be hosted on a single IP. In order support this situation in TLS secured scenarios the SNI extension is used to notify the server of the requested domain name at TLS handshake time. This PR enables SNI during TLS handshake in hivemq-mqtt-client.

**Changes**
- Improve SslUtilTest to work with more recent JDKs (in my case amazon corretto 8.222.10.1)
- Rework SslUtil to use DelegatingSslContext for configuration
- Pass hostname / port into SSL handler to enable SNI