### PR TITLE
feature/allow-querystring-in-mqttwebsocketconfig

### DIFF
--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttWebSocketConfigImpl.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttWebSocketConfigImpl.java
@@ -27,14 +27,16 @@ import org.jetbrains.annotations.Nullable;
 public class MqttWebSocketConfigImpl implements MqttWebSocketConfig {
 
     static final @NotNull MqttWebSocketConfigImpl DEFAULT =
-            new MqttWebSocketConfigImpl(DEFAULT_SERVER_PATH, DEFAULT_MQTT_SUBPROTOCOL);
+            new MqttWebSocketConfigImpl(DEFAULT_SERVER_PATH, DEFAULT_QUERY_STRING, DEFAULT_MQTT_SUBPROTOCOL);
 
     private final @NotNull String serverPath;
+    private final @NotNull String queryString;
     private final @NotNull String subprotocol;
 
-    MqttWebSocketConfigImpl(final @NotNull String serverPath, final @NotNull String subprotocol) {
+    MqttWebSocketConfigImpl(final @NotNull String serverPath, final @NotNull String queryString, final @NotNull String subprotocol) {
         this.serverPath = serverPath;
         this.subprotocol = subprotocol;
+        this.queryString = queryString;
     }
 
     @Override
@@ -42,6 +44,11 @@ public class MqttWebSocketConfigImpl implements MqttWebSocketConfig {
         return serverPath;
     }
 
+    @Override
+    public @NotNull String getQueryString() {
+        return queryString;
+    }
+    
     @Override
     public @NotNull String getSubprotocol() {
         return subprotocol;
@@ -62,12 +69,13 @@ public class MqttWebSocketConfigImpl implements MqttWebSocketConfig {
         }
         final MqttWebSocketConfigImpl that = (MqttWebSocketConfigImpl) o;
 
-        return serverPath.equals(that.serverPath) && subprotocol.equals(that.subprotocol);
+        return serverPath.equals(that.serverPath) && queryString.equals(that.queryString) && subprotocol.equals(that.subprotocol);
     }
 
     @Override
     public int hashCode() {
         int result = serverPath.hashCode();
+        result = 31 * result + queryString.hashCode();
         result = 31 * result + subprotocol.hashCode();
         return result;
     }

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttWebSocketConfigImpl.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttWebSocketConfigImpl.java
@@ -35,8 +35,8 @@ public class MqttWebSocketConfigImpl implements MqttWebSocketConfig {
 
     MqttWebSocketConfigImpl(final @NotNull String serverPath, final @NotNull String queryString, final @NotNull String subprotocol) {
         this.serverPath = serverPath;
-        this.subprotocol = subprotocol;
         this.queryString = queryString;
+        this.subprotocol = subprotocol;
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttWebSocketConfigImplBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttWebSocketConfigImplBuilder.java
@@ -52,7 +52,7 @@ public abstract class MqttWebSocketConfigImplBuilder<B extends MqttWebSocketConf
     }
 
     public @NotNull B queryString(final @Nullable String queryString) {
-        this.queryString = Checks.notNull(subprotocol, "QueryString");
+        this.queryString = Checks.notNull(subprotocol, "Query string");
         return self();
     }
     

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttWebSocketConfigImplBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttWebSocketConfigImplBuilder.java
@@ -30,6 +30,7 @@ import java.util.function.Function;
 public abstract class MqttWebSocketConfigImplBuilder<B extends MqttWebSocketConfigImplBuilder<B>> {
 
     private @NotNull String serverPath = MqttWebSocketConfigImpl.DEFAULT_SERVER_PATH;
+    private @NotNull String queryString = MqttWebSocketConfigImpl.DEFAULT_QUERY_STRING;
     private @NotNull String subprotocol = MqttWebSocketConfigImpl.DEFAULT_MQTT_SUBPROTOCOL;
 
     MqttWebSocketConfigImplBuilder() {}
@@ -37,6 +38,7 @@ public abstract class MqttWebSocketConfigImplBuilder<B extends MqttWebSocketConf
     MqttWebSocketConfigImplBuilder(final @Nullable MqttWebSocketConfigImpl webSocketConfig) {
         if (webSocketConfig != null) {
             serverPath = webSocketConfig.getServerPath();
+            queryString = webSocketConfig.getQueryString();
             subprotocol = webSocketConfig.getSubprotocol();
         }
     }
@@ -49,13 +51,18 @@ public abstract class MqttWebSocketConfigImplBuilder<B extends MqttWebSocketConf
         return self();
     }
 
+    public @NotNull B queryString(final @Nullable String queryString) {
+        this.queryString = Checks.notNull(subprotocol, "QueryString");
+        return self();
+    }
+    
     public @NotNull B subprotocol(final @Nullable String subprotocol) {
         this.subprotocol = Checks.notNull(subprotocol, "Subprotocol");
         return self();
     }
 
     public @NotNull MqttWebSocketConfigImpl build() {
-        return new MqttWebSocketConfigImpl(serverPath, subprotocol);
+        return new MqttWebSocketConfigImpl(serverPath, queryString, subprotocol);
     }
 
     public static class Default extends MqttWebSocketConfigImplBuilder<Default> implements MqttWebSocketConfigBuilder {

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttWebSocketConfigImplBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttWebSocketConfigImplBuilder.java
@@ -52,7 +52,7 @@ public abstract class MqttWebSocketConfigImplBuilder<B extends MqttWebSocketConf
     }
 
     public @NotNull B queryString(final @Nullable String queryString) {
-        this.queryString = Checks.notNull(subprotocol, "Query string");
+        this.queryString = Checks.notNull(queryString, "Query string");
         return self();
     }
     

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/websocket/MqttWebSocketInitializer.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/websocket/MqttWebSocketInitializer.java
@@ -76,7 +76,7 @@ public class MqttWebSocketInitializer extends ChannelInboundHandlerAdapter {
 
         final URI uri = new URI((clientConfig.getTransportConfig().getRawSslConfig() == null) ? WEBSOCKET_URI_SCHEME :
                 WEBSOCKET_TLS_URI_SCHEME, null, clientConfig.getServerHost(), clientConfig.getServerPort(),
-                "/" + webSocketConfig.getServerPath(), null, null);
+                "/" + webSocketConfig.getServerPath(), webSocketConfig.getQueryString(), null);
 
         final WebSocketClientProtocolHandler webSocketClientProtocolHandler =
                 new WebSocketClientProtocolHandler(uri, WebSocketVersion.V13, webSocketConfig.getSubprotocol(), true,

--- a/src/main/java/com/hivemq/client/mqtt/MqttWebSocketConfig.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttWebSocketConfig.java
@@ -35,6 +35,10 @@ public interface MqttWebSocketConfig {
      */
     @NotNull String DEFAULT_SERVER_PATH = "";
     /**
+     * The default WebSocket query string.
+     */
+    @NotNull String DEFAULT_QUERY_STRING = "";
+    /**
      * The default WebSocket subprotocol.
      * <p>
      * See the <a href="https://www.iana.org/assignments/websocket/websocket.xml#subprotocol-name">WebSocket Subprotocol
@@ -56,6 +60,11 @@ public interface MqttWebSocketConfig {
      */
     @NotNull String getServerPath();
 
+    /**
+     * @return the WebSocket query string.
+     */
+    @NotNull String getQueryString();
+    
     /**
      * @return the WebSocket subprotocol.
      */

--- a/src/main/java/com/hivemq/client/mqtt/MqttWebSocketConfigBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttWebSocketConfigBuilderBase.java
@@ -39,7 +39,7 @@ public interface MqttWebSocketConfigBuilderBase<B extends MqttWebSocketConfigBui
     @NotNull B serverPath(@NotNull String serverPath);
 
     /**
-     * Sets the {@link MqttWebSocketConfig#getQueryString() queryString}.
+     * Sets the {@link MqttWebSocketConfig#getQueryString() query string}.
      *
      * @param queryString the query string.
      * @return the builder.

--- a/src/main/java/com/hivemq/client/mqtt/MqttWebSocketConfigBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttWebSocketConfigBuilderBase.java
@@ -39,6 +39,14 @@ public interface MqttWebSocketConfigBuilderBase<B extends MqttWebSocketConfigBui
     @NotNull B serverPath(@NotNull String serverPath);
 
     /**
+     * Sets the {@link MqttWebSocketConfig#getQueryString() queryString}.
+     *
+     * @param queryString the query string.
+     * @return the builder.
+     */
+    @NotNull B queryString(@NotNull String queryString);
+    
+    /**
      * Sets the {@link MqttWebSocketConfig#getSubprotocol() subprotocol}.
      *
      * @param subprotocol the subprotocol.


### PR DESCRIPTION
**Motivation**
Allow querystring in MqttWebsocketConfig
Resolves #335 

**Changes**
Add queryString in MqttWebSocketConfig.
Use queryString of the new MqttWeSocketConfig in URI inside of initChannel of MqttWebSocketInitializer class.