### PR TITLE
Releasing event loop when connection failed and not reconnecting

### DIFF
--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/MqttChannelInitializer.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/MqttChannelInitializer.java
@@ -115,6 +115,5 @@ public class MqttChannelInitializer extends ChannelInitializer<Channel> {
         ctx.close();
         MqttConnAckSingle.reconnect(clientConfig, MqttDisconnectSource.CLIENT, new ConnectionFailedException(cause),
                 connect, connAckFlow, ctx.channel().eventLoop());
-        clientConfig.releaseEventLoop();
     }
 }

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/connect/MqttConnAckSingle.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/connect/MqttConnAckSingle.java
@@ -139,7 +139,6 @@ public class MqttConnAckSingle extends Single<Mqtt5ConnAck> {
 
         if (reconnector.isReconnect()) {
             clientConfig.getRawState().set(DISCONNECTED_RECONNECT);
-            clientConfig.acquireEventLoop();
             eventLoop.schedule(() -> {
                 reconnector.getFuture().whenComplete((ignored, throwable) -> {
                     if (reconnector.isReconnect()) {
@@ -163,6 +162,7 @@ public class MqttConnAckSingle extends Single<Mqtt5ConnAck> {
             }, reconnector.getDelay(TimeUnit.NANOSECONDS), TimeUnit.NANOSECONDS);
         } else {
             clientConfig.getRawState().set(DISCONNECTED);
+            clientConfig.releaseEventLoop();
             if (flow != null) {
                 flow.onError(cause);
             }

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/disconnect/MqttDisconnectHandler.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/disconnect/MqttDisconnectHandler.java
@@ -240,12 +240,6 @@ public class MqttDisconnectHandler extends MqttConnectionAwareHandler {
     }
 
     @Override
-    public void channelUnregistered(final @NotNull ChannelHandlerContext ctx) {
-        ctx.fireChannelUnregistered();
-        clientConfig.releaseEventLoop();
-    }
-
-    @Override
     public boolean isSharable() {
         return false;
     }


### PR DESCRIPTION
**Motivation**
Automatic thread management must work in any error case.
Currently the event loop is not released in an edge case when the host name is not found and reconnect is not enabled.

**Changes**
- Release client event loop on all connection failures