### PR TITLE
Feature/proxy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ buildscript {
 }
 
 plugins {
-    id 'nebula.optional-base' version '3.0.3'
     id 'com.github.johnrengelman.shadow' version '4.0.4' apply false
     id 'biz.aQute.bnd.builder' version '4.2.0' apply false
     id 'com.github.hierynomus.license' version '0.14.0' apply false
@@ -91,13 +90,27 @@ dependencies {
     implementation group: 'org.jetbrains', name: 'annotations', version: jetbrainsAnnotationsVersion
     implementation group: 'com.google.dagger', name: 'dagger', version: daggerVersion
 
-    implementation group: 'io.netty', name: 'netty-codec-http', version: nettyVersion, optional
-    implementation group: 'io.netty', name: 'netty-handler-proxy', version: nettyVersion, optional
-    implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: nettyVersion, classifier: 'linux-x86_64', optional
-
     compileOnly group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
 
     annotationProcessor group: 'com.google.dagger', name: 'dagger-compiler', version: daggerVersion
+}
+
+
+/* ******************** optional dependencies ******************** */
+
+def features = ['websocket', 'proxy', 'epoll']
+java {
+    features.each {
+        registerFeature(it) {
+            usingSourceSet(sourceSets.main)
+        }
+    }
+}
+
+dependencies {
+    websocketImplementation group: 'io.netty', name: 'netty-codec-http', version: nettyVersion
+    proxyImplementation group: 'io.netty', name: 'netty-handler-proxy', version: nettyVersion
+    epollImplementation group: 'io.netty', name: 'netty-transport-native-epoll', version: nettyVersion, classifier: 'linux-x86_64'
 }
 
 
@@ -246,11 +259,12 @@ allprojects {
                             url = project.issuesUrl
                         }
                     }
-                    artifact javadocJar
-                    artifact sourcesJar
                 }
                 normal(MavenPublication) {
-                    from components.java
+                    from project.components.java
+                    artifact project.tasks.javadocJar
+                    artifact project.tasks.sourcesJar
+                    suppressAllPomMetadataWarnings()
                 }
             }
         }
@@ -286,6 +300,19 @@ allprojects {
                 }
             }
         }
+
+        // workaround for publishing gradle metadata https://github.com/bintray/gradle-bintray-plugin/issues/229
+        //noinspection UnnecessaryQualifiedReference
+        project.tasks.withType(com.jfrog.bintray.gradle.tasks.BintrayUploadTask) {
+            doFirst {
+                publishing.publications.withType(MavenPublication).each { publication ->
+                    def moduleFile = new File(new File(new File(project.buildDir, 'publications'), publication.name), 'module.json')
+                    if (moduleFile.exists()) {
+                        publication.artifact(moduleFile).setExtension('module')
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -295,9 +322,11 @@ allprojects {
             publications {
                 shaded(MavenPublication) {
                     artifactId project.name + '-' + project.shadedAppendix
-                    artifact shadowJar
-                    pom.withXml { xml ->
-                        def dependenciesNode = xml.asNode().appendNode('dependencies')
+                    artifact project.tasks.shadowJar
+                    artifact project.tasks.javadocJar
+                    artifact project.tasks.sourcesJar
+                    pom.withXml {
+                        def dependenciesNode = asNode().appendNode('dependencies')
 
                         project.configurations.api.allDependencies.each {
                             def dependencyNode = dependenciesNode.appendNode('dependency')
@@ -306,6 +335,33 @@ allprojects {
                             dependencyNode.appendNode('version', it.version)
                             dependencyNode.appendNode('scope', 'compile')
                         }
+                    }
+                }
+            }
+        }
+    }
+}
+
+features.each { feature ->
+    publishing {
+        publications {
+            create(feature, MavenPublication) {
+                artifactId project.name + '-' + feature
+                pom.withXml {
+                    def dependenciesNode = asNode().appendNode('dependencies')
+
+                    def rootDependencyNode = dependenciesNode.appendNode('dependency')
+                    rootDependencyNode.appendNode('groupId', project.group)
+                    rootDependencyNode.appendNode('artifactId', project.name)
+                    rootDependencyNode.appendNode('version', project.version)
+                    rootDependencyNode.appendNode('scope', 'compile')
+
+                    project.configurations.getByName(feature + 'Implementation').allDependencies.each {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                        dependencyNode.appendNode('scope', 'runtime')
                     }
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
 }
 
 plugins {
+    id 'nebula.optional-base' version '3.0.3'
     id 'com.github.johnrengelman.shadow' version '4.0.4' apply false
     id 'biz.aQute.bnd.builder' version '4.2.0' apply false
     id 'com.github.hierynomus.license' version '0.14.0' apply false
@@ -80,14 +81,23 @@ ext {
 
 dependencies {
     api group: 'io.reactivex.rxjava2', name: 'rxjava', version: rxJavaVersion
+
+    implementation group: 'io.netty', name: 'netty-buffer', version: nettyVersion
+    implementation group: 'io.netty', name: 'netty-codec', version: nettyVersion
+    implementation group: 'io.netty', name: 'netty-common', version: nettyVersion
     implementation group: 'io.netty', name: 'netty-handler', version: nettyVersion
-    implementation group: 'io.netty', name: 'netty-codec-http', version: nettyVersion
-    implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: nettyVersion, classifier: 'linux-x86_64'
+    implementation group: 'io.netty', name: 'netty-transport', version: nettyVersion
     implementation group: 'org.jctools', name: 'jctools-core', version: jcToolsVersion
     implementation group: 'org.jetbrains', name: 'annotations', version: jetbrainsAnnotationsVersion
     implementation group: 'com.google.dagger', name: 'dagger', version: daggerVersion
-    annotationProcessor group: 'com.google.dagger', name: 'dagger-compiler', version: daggerVersion
+
+    implementation group: 'io.netty', name: 'netty-codec-http', version: nettyVersion, optional
+    implementation group: 'io.netty', name: 'netty-handler-proxy', version: nettyVersion, optional
+    implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: nettyVersion, classifier: 'linux-x86_64', optional
+
     compileOnly group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
+
+    annotationProcessor group: 'com.google.dagger', name: 'dagger-compiler', version: daggerVersion
 }
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Wed Sep 25 23:53:09 CEST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttClientExecutorConfigImplBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttClientExecutorConfigImplBuilder.java
@@ -88,7 +88,7 @@ public abstract class MqttClientExecutorConfigImplBuilder<B extends MqttClientEx
 
         private final @NotNull Function<? super MqttClientExecutorConfigImpl, P> parentConsumer;
 
-        public Nested(
+        Nested(
                 final @NotNull MqttClientExecutorConfigImpl executorConfig,
                 final @NotNull Function<? super MqttClientExecutorConfigImpl, P> parentConsumer) {
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttClientSslConfigImplBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttClientSslConfigImplBuilder.java
@@ -105,7 +105,7 @@ public abstract class MqttClientSslConfigImplBuilder<B extends MqttClientSslConf
 
         private final @NotNull Function<? super MqttClientSslConfigImpl, P> parentConsumer;
 
-        public Nested(
+        Nested(
                 final @Nullable MqttClientSslConfigImpl sslConfig,
                 final @NotNull Function<? super MqttClientSslConfigImpl, P> parentConsumer) {
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttClientTransportConfigImpl.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttClientTransportConfigImpl.java
@@ -17,14 +17,12 @@
 
 package com.hivemq.client.internal.mqtt;
 
-import com.hivemq.client.mqtt.MqttClient;
-import com.hivemq.client.mqtt.MqttClientSslConfig;
-import com.hivemq.client.mqtt.MqttClientTransportConfig;
-import com.hivemq.client.mqtt.MqttWebSocketConfig;
+import com.hivemq.client.mqtt.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.net.InetSocketAddress;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -34,22 +32,24 @@ public class MqttClientTransportConfigImpl implements MqttClientTransportConfig 
 
     public static final @NotNull MqttClientTransportConfigImpl DEFAULT = new MqttClientTransportConfigImpl(
             InetSocketAddress.createUnresolved(MqttClient.DEFAULT_SERVER_HOST, MqttClient.DEFAULT_SERVER_PORT), null,
-            null, null);
+            null, null, null);
 
     private final @NotNull InetSocketAddress serverAddress;
     private final @Nullable InetSocketAddress localAddress;
     private final @Nullable MqttClientSslConfigImpl sslConfig;
     private final @Nullable MqttWebSocketConfigImpl webSocketConfig;
+    private final @Nullable MqttProxyConfigImpl proxyConfig;
 
     MqttClientTransportConfigImpl(
             final @NotNull InetSocketAddress serverAddress, final @Nullable InetSocketAddress localAddress,
-            final @Nullable MqttClientSslConfigImpl sslConfig,
-            final @Nullable MqttWebSocketConfigImpl webSocketConfig) {
+            final @Nullable MqttClientSslConfigImpl sslConfig, final @Nullable MqttWebSocketConfigImpl webSocketConfig,
+            final @Nullable MqttProxyConfigImpl proxyConfig) {
 
         this.serverAddress = serverAddress;
         this.localAddress = localAddress;
         this.sslConfig = sslConfig;
         this.webSocketConfig = webSocketConfig;
+        this.proxyConfig = proxyConfig;
     }
 
     @Override
@@ -85,7 +85,41 @@ public class MqttClientTransportConfigImpl implements MqttClientTransportConfig 
     }
 
     @Override
+    public @NotNull Optional<MqttProxyConfig> getProxyConfig() {
+        return Optional.ofNullable(proxyConfig);
+    }
+
+    public @Nullable MqttProxyConfigImpl getRawProxyConfig() {
+        return proxyConfig;
+    }
+
+    @Override
     public @NotNull MqttClientTransportConfigImplBuilder.Default extend() {
         return new MqttClientTransportConfigImplBuilder.Default(this);
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MqttClientTransportConfigImpl)) {
+            return false;
+        }
+        final MqttClientTransportConfigImpl that = (MqttClientTransportConfigImpl) o;
+
+        return serverAddress.equals(that.serverAddress) && Objects.equals(localAddress, that.localAddress) &&
+                Objects.equals(sslConfig, that.sslConfig) && Objects.equals(webSocketConfig, that.webSocketConfig) &&
+                Objects.equals(proxyConfig, that.proxyConfig);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = serverAddress.hashCode();
+        result = 31 * result + Objects.hashCode(localAddress);
+        result = 31 * result + Objects.hashCode(sslConfig);
+        result = 31 * result + Objects.hashCode(webSocketConfig);
+        result = 31 * result + Objects.hashCode(proxyConfig);
+        return result;
     }
 }

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttProxyConfigImpl.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttProxyConfigImpl.java
@@ -18,7 +18,7 @@
 package com.hivemq.client.internal.mqtt;
 
 import com.hivemq.client.mqtt.MqttProxyConfig;
-import com.hivemq.client.mqtt.MqttProxyType;
+import com.hivemq.client.mqtt.MqttProxyProtocol;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -31,24 +31,24 @@ import java.util.Optional;
  */
 public class MqttProxyConfigImpl implements MqttProxyConfig {
 
-    private final @NotNull MqttProxyType type;
+    private final @NotNull MqttProxyProtocol protocol;
     private final @NotNull InetSocketAddress address;
     private final @Nullable String username;
     private final @Nullable String password;
 
     MqttProxyConfigImpl(
-            final @NotNull MqttProxyType type, final @NotNull InetSocketAddress address,
+            final @NotNull MqttProxyProtocol protocol, final @NotNull InetSocketAddress address,
             final @Nullable String username, final @Nullable String password) {
 
-        this.type = type;
+        this.protocol = protocol;
         this.address = address;
         this.username = username;
         this.password = password;
     }
 
     @Override
-    public @NotNull MqttProxyType getProxyType() {
-        return type;
+    public @NotNull MqttProxyProtocol getProxyProtocol() {
+        return protocol;
     }
 
     @Override
@@ -89,13 +89,13 @@ public class MqttProxyConfigImpl implements MqttProxyConfig {
         }
         final MqttProxyConfigImpl that = (MqttProxyConfigImpl) o;
 
-        return (type == that.type) && address.equals(that.address) && Objects.equals(username, that.username) &&
+        return (protocol == that.protocol) && address.equals(that.address) && Objects.equals(username, that.username) &&
                 Objects.equals(password, that.password);
     }
 
     @Override
     public int hashCode() {
-        int result = type.hashCode();
+        int result = protocol.hashCode();
         result = 31 * result + address.hashCode();
         result = 31 * result + Objects.hashCode(username);
         result = 31 * result + Objects.hashCode(password);

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttProxyConfigImpl.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttProxyConfigImpl.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 dc-square and the HiveMQ MQTT Client Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hivemq.client.internal.mqtt;
+
+import com.hivemq.client.mqtt.MqttProxyConfig;
+import com.hivemq.client.mqtt.MqttProxyType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.InetSocketAddress;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * @author Silvio Giebl
+ */
+public class MqttProxyConfigImpl implements MqttProxyConfig {
+
+    private final @NotNull MqttProxyType type;
+    private final @NotNull InetSocketAddress address;
+    private final @Nullable String username;
+    private final @Nullable String password;
+
+    MqttProxyConfigImpl(
+            final @NotNull MqttProxyType type, final @NotNull InetSocketAddress address,
+            final @Nullable String username, final @Nullable String password) {
+
+        this.type = type;
+        this.address = address;
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public @NotNull MqttProxyType getProxyType() {
+        return type;
+    }
+
+    @Override
+    public @NotNull InetSocketAddress getProxyAddress() {
+        return address;
+    }
+
+    @Override
+    public @NotNull Optional<String> getProxyUsername() {
+        return Optional.ofNullable(username);
+    }
+
+    public @Nullable String getRawProxyUsername() {
+        return username;
+    }
+
+    @Override
+    public @NotNull Optional<String> getProxyPassword() {
+        return Optional.ofNullable(password);
+    }
+
+    public @Nullable String getRawProxyPassword() {
+        return password;
+    }
+
+    @Override
+    public @NotNull MqttProxyConfigImplBuilder.Default extend() {
+        return new MqttProxyConfigImplBuilder.Default(this);
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MqttProxyConfigImpl)) {
+            return false;
+        }
+        final MqttProxyConfigImpl that = (MqttProxyConfigImpl) o;
+
+        return (type == that.type) && address.equals(that.address) && Objects.equals(username, that.username) &&
+                Objects.equals(password, that.password);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type.hashCode();
+        result = 31 * result + address.hashCode();
+        result = 31 * result + Objects.hashCode(username);
+        result = 31 * result + Objects.hashCode(password);
+        return result;
+    }
+}

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttProxyConfigImplBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttProxyConfigImplBuilder.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2018 dc-square and the HiveMQ MQTT Client Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hivemq.client.internal.mqtt;
+
+import com.hivemq.client.internal.util.Checks;
+import com.hivemq.client.mqtt.MqttProxyConfigBuilder;
+import com.hivemq.client.mqtt.MqttProxyType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.function.Function;
+
+/**
+ * @author Silvio Giebl
+ */
+public abstract class MqttProxyConfigImplBuilder<B extends MqttProxyConfigImplBuilder<B>> {
+
+    private @NotNull MqttProxyType type = MqttProxyConfigImpl.DEFAULT_PROXY_TYPE;
+    private @Nullable InetSocketAddress address;
+    private @NotNull Object host = MqttProxyConfigImpl.DEFAULT_PROXY_HOST; // String or InetAddress
+    private int port = -1;
+    private @Nullable String username;
+    private @Nullable String password;
+
+    MqttProxyConfigImplBuilder() {}
+
+    MqttProxyConfigImplBuilder(final @Nullable MqttProxyConfigImpl proxyConfig) {
+        if (proxyConfig != null) {
+            address = proxyConfig.getProxyAddress();
+            username = proxyConfig.getRawProxyUsername();
+            password = proxyConfig.getRawProxyPassword();
+        }
+    }
+
+    abstract @NotNull B self();
+
+    public @NotNull B proxyType(final @Nullable MqttProxyType type) {
+        this.type = Checks.notNull(type, "Proxy type");
+        return self();
+    }
+
+    public @NotNull B proxyAddress(final @Nullable InetSocketAddress address) {
+        this.address = Checks.notNull(address, "Proxy address");
+        return self();
+    }
+
+    public @NotNull B proxyHost(final @Nullable String host) {
+        setProxyHost(Checks.notEmpty(host, "Proxy host"));
+        return self();
+    }
+
+    public @NotNull B proxyHost(final @Nullable InetAddress host) {
+        setProxyHost(Checks.notNull(host, "Proxy host"));
+        return self();
+    }
+
+    private void setProxyHost(final @NotNull Object host) {
+        this.host = host;
+        if (address != null) {
+            port = address.getPort();
+            address = null;
+        }
+    }
+
+    public @NotNull B proxyPort(final int port) {
+        this.port = Checks.unsignedShort(port, "Proxy port");
+        if (address != null) {
+            final InetAddress inetAddress = address.getAddress();
+            if (inetAddress != null) {
+                host = inetAddress;
+            } else {
+                host = address.getHostString();
+            }
+            address = null;
+        }
+        return self();
+    }
+
+    public @NotNull B proxyUsername(final @Nullable String username) {
+        this.username = username;
+        return self();
+    }
+
+    public @NotNull B proxyPassword(final @Nullable String password) {
+        this.password = password;
+        return self();
+    }
+
+    private @NotNull InetSocketAddress getProxyAddress() {
+        if (address != null) {
+            return address;
+        }
+        if (host instanceof InetAddress) {
+            return new InetSocketAddress((InetAddress) host, getProxyPort());
+        }
+        return InetSocketAddress.createUnresolved((String) host, getProxyPort());
+    }
+
+    private int getProxyPort() {
+        if (port != -1) {
+            return port;
+        }
+        switch (type) {
+            case SOCKS_4:
+            case SOCKS_5:
+                return MqttProxyConfigImpl.DEFAULT_SOCKS_PROXY_PORT;
+            case HTTP:
+            default:
+                return MqttProxyConfigImpl.DEFAULT_HTTP_PROXY_PORT;
+        }
+    }
+
+    public @NotNull MqttProxyConfigImpl build() {
+        return new MqttProxyConfigImpl(type, getProxyAddress(), username, password);
+    }
+
+    public static class Default extends MqttProxyConfigImplBuilder<Default> implements MqttProxyConfigBuilder {
+
+        public Default() {}
+
+        Default(final @NotNull MqttProxyConfigImpl proxyConfig) {
+            super(proxyConfig);
+        }
+
+        @Override
+        @NotNull Default self() {
+            return this;
+        }
+    }
+
+    public static class Nested<P> extends MqttProxyConfigImplBuilder<Nested<P>>
+            implements MqttProxyConfigBuilder.Nested<P> {
+
+        private final @NotNull Function<? super MqttProxyConfigImpl, P> parentConsumer;
+
+        Nested(
+                final @Nullable MqttProxyConfigImpl proxyConfig,
+                final @NotNull Function<? super MqttProxyConfigImpl, P> parentConsumer) {
+
+            super(proxyConfig);
+            this.parentConsumer = parentConsumer;
+        }
+
+        @Override
+        @NotNull Nested<P> self() {
+            return this;
+        }
+
+        @Override
+        public @NotNull P applyProxyConfig() {
+            return parentConsumer.apply(build());
+        }
+    }
+}

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttProxyConfigImplBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttProxyConfigImplBuilder.java
@@ -19,7 +19,7 @@ package com.hivemq.client.internal.mqtt;
 
 import com.hivemq.client.internal.util.Checks;
 import com.hivemq.client.mqtt.MqttProxyConfigBuilder;
-import com.hivemq.client.mqtt.MqttProxyType;
+import com.hivemq.client.mqtt.MqttProxyProtocol;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -32,7 +32,7 @@ import java.util.function.Function;
  */
 public abstract class MqttProxyConfigImplBuilder<B extends MqttProxyConfigImplBuilder<B>> {
 
-    private @NotNull MqttProxyType type = MqttProxyConfigImpl.DEFAULT_PROXY_TYPE;
+    private @NotNull MqttProxyProtocol protocol = MqttProxyConfigImpl.DEFAULT_PROXY_PROTOCOL;
     private @Nullable InetSocketAddress address;
     private @NotNull Object host = MqttProxyConfigImpl.DEFAULT_PROXY_HOST; // String or InetAddress
     private int port = -1;
@@ -51,8 +51,8 @@ public abstract class MqttProxyConfigImplBuilder<B extends MqttProxyConfigImplBu
 
     abstract @NotNull B self();
 
-    public @NotNull B proxyType(final @Nullable MqttProxyType type) {
-        this.type = Checks.notNull(type, "Proxy type");
+    public @NotNull B proxyProtocol(final @Nullable MqttProxyProtocol protocol) {
+        this.protocol = Checks.notNull(protocol, "Proxy protocol");
         return self();
     }
 
@@ -117,7 +117,7 @@ public abstract class MqttProxyConfigImplBuilder<B extends MqttProxyConfigImplBu
         if (port != -1) {
             return port;
         }
-        switch (type) {
+        switch (protocol) {
             case SOCKS_4:
             case SOCKS_5:
                 return MqttProxyConfigImpl.DEFAULT_SOCKS_PROXY_PORT;
@@ -128,7 +128,7 @@ public abstract class MqttProxyConfigImplBuilder<B extends MqttProxyConfigImplBu
     }
 
     public @NotNull MqttProxyConfigImpl build() {
-        return new MqttProxyConfigImpl(type, getProxyAddress(), username, password);
+        return new MqttProxyConfigImpl(protocol, getProxyAddress(), username, password);
     }
 
     public static class Default extends MqttProxyConfigImplBuilder<Default> implements MqttProxyConfigBuilder {

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttProxyConfigImplBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttProxyConfigImplBuilder.java
@@ -43,6 +43,7 @@ public abstract class MqttProxyConfigImplBuilder<B extends MqttProxyConfigImplBu
 
     MqttProxyConfigImplBuilder(final @Nullable MqttProxyConfigImpl proxyConfig) {
         if (proxyConfig != null) {
+            protocol = proxyConfig.getProxyProtocol();
             address = proxyConfig.getProxyAddress();
             username = proxyConfig.getRawProxyUsername();
             password = proxyConfig.getRawProxyPassword();
@@ -135,7 +136,7 @@ public abstract class MqttProxyConfigImplBuilder<B extends MqttProxyConfigImplBu
 
         public Default() {}
 
-        Default(final @NotNull MqttProxyConfigImpl proxyConfig) {
+        Default(final @Nullable MqttProxyConfigImpl proxyConfig) {
             super(proxyConfig);
         }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttRxClientBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttRxClientBuilder.java
@@ -46,7 +46,7 @@ public class MqttRxClientBuilder extends MqttRxClientBuilderBase<MqttRxClientBui
 
     public MqttRxClientBuilder() {}
 
-    MqttRxClientBuilder(final @NotNull MqttRxClientBuilderBase clientBuilder) {
+    MqttRxClientBuilder(final @NotNull MqttRxClientBuilderBase<?> clientBuilder) {
         super(clientBuilder);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttWebSocketConfigImplBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttWebSocketConfigImplBuilder.java
@@ -84,7 +84,7 @@ public abstract class MqttWebSocketConfigImplBuilder<B extends MqttWebSocketConf
 
         private final @NotNull Function<? super MqttWebSocketConfigImpl, P> parentConsumer;
 
-        public Nested(
+        Nested(
                 final @Nullable MqttWebSocketConfigImpl webSocketConfig,
                 final @NotNull Function<? super MqttWebSocketConfigImpl, P> parentConsumer) {
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoder.java
@@ -155,8 +155,7 @@ public class Mqtt5PublishDecoder implements MqttMessageDecoder {
                         throw new MqttDecoderException("malformed subscription identifier");
                     }
                     if (subscriptionIdentifier == 0) {
-                        throw new MqttDecoderException(
-                                Mqtt5DisconnectReasonCode.PROTOCOL_ERROR,
+                        throw new MqttDecoderException(Mqtt5DisconnectReasonCode.PROTOCOL_ERROR,
                                 "subscription identifier must not be 0");
                     }
                     subscriptionIdentifiersBuilder.add(subscriptionIdentifier);
@@ -174,8 +173,7 @@ public class Mqtt5PublishDecoder implements MqttMessageDecoder {
         if (topicAlias != DEFAULT_NO_TOPIC_ALIAS) {
             final MqttTopicImpl[] topicAliasMapping = context.getTopicAliasMapping();
             if ((topicAliasMapping == null) || (topicAlias > topicAliasMapping.length)) {
-                throw new MqttDecoderException(
-                        Mqtt5DisconnectReasonCode.TOPIC_ALIAS_INVALID,
+                throw new MqttDecoderException(Mqtt5DisconnectReasonCode.TOPIC_ALIAS_INVALID,
                         "topic alias must not exceed topic alias maximum");
             }
             if (topic == null) {
@@ -189,8 +187,7 @@ public class Mqtt5PublishDecoder implements MqttMessageDecoder {
                 topicAlias |= TOPIC_ALIAS_FLAG_NEW;
             }
         } else if (topic == null) {
-            throw new MqttDecoderException(
-                    Mqtt5DisconnectReasonCode.PROTOCOL_ERROR,
+            throw new MqttDecoderException(Mqtt5DisconnectReasonCode.PROTOCOL_ERROR,
                     "topic alias must be present if topic name is zero length");
         }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttTopicImplBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttTopicImplBuilder.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 /**
  * @author Silvio Giebl
  */
-public abstract class MqttTopicImplBuilder<B extends MqttTopicImplBuilder> {
+public abstract class MqttTopicImplBuilder<B extends MqttTopicImplBuilder<B>> {
 
     @Nullable StringBuilder stringBuilder;
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/MqttChannelInitializer.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/MqttChannelInitializer.java
@@ -25,7 +25,7 @@ import com.hivemq.client.internal.mqtt.handler.connect.MqttConnAckSingle;
 import com.hivemq.client.internal.mqtt.handler.connect.MqttConnectHandler;
 import com.hivemq.client.internal.mqtt.handler.disconnect.MqttDisconnectHandler;
 import com.hivemq.client.internal.mqtt.handler.proxy.MqttProxyInitializer;
-import com.hivemq.client.internal.mqtt.handler.ssl.SslInitializer;
+import com.hivemq.client.internal.mqtt.handler.ssl.MqttSslInitializer;
 import com.hivemq.client.internal.mqtt.handler.websocket.MqttWebSocketInitializer;
 import com.hivemq.client.internal.mqtt.ioc.ConnectionScope;
 import com.hivemq.client.internal.mqtt.message.connect.MqttConnect;
@@ -100,7 +100,7 @@ public class MqttChannelInitializer extends ChannelInboundHandlerAdapter {
         }
         final MqttClientSslConfigImpl sslConfig = transportConfig.getRawSslConfig();
         if (sslConfig != null) {
-            SslInitializer.initChannel(channel, sslConfig, transportConfig.getServerAddress());
+            MqttSslInitializer.initChannel(channel, sslConfig, transportConfig.getServerAddress());
         }
         final MqttWebSocketConfigImpl webSocketConfig = transportConfig.getRawWebSocketConfig();
         if (webSocketConfig != null) {

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/MqttChannelInitializer.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/MqttChannelInitializer.java
@@ -17,17 +17,15 @@
 
 package com.hivemq.client.internal.mqtt.handler;
 
-import com.hivemq.client.internal.mqtt.MqttClientConfig;
-import com.hivemq.client.internal.mqtt.MqttClientSslConfigImpl;
-import com.hivemq.client.internal.mqtt.MqttClientTransportConfigImpl;
-import com.hivemq.client.internal.mqtt.MqttWebSocketConfigImpl;
+import com.hivemq.client.internal.mqtt.*;
 import com.hivemq.client.internal.mqtt.codec.encoder.MqttEncoder;
 import com.hivemq.client.internal.mqtt.handler.auth.MqttAuthHandler;
 import com.hivemq.client.internal.mqtt.handler.connect.MqttConnAckFlow;
 import com.hivemq.client.internal.mqtt.handler.connect.MqttConnAckSingle;
 import com.hivemq.client.internal.mqtt.handler.connect.MqttConnectHandler;
 import com.hivemq.client.internal.mqtt.handler.disconnect.MqttDisconnectHandler;
-import com.hivemq.client.internal.mqtt.handler.ssl.SslUtil;
+import com.hivemq.client.internal.mqtt.handler.proxy.MqttProxyInitializer;
+import com.hivemq.client.internal.mqtt.handler.ssl.SslInitializer;
 import com.hivemq.client.internal.mqtt.handler.websocket.MqttWebSocketInitializer;
 import com.hivemq.client.internal.mqtt.ioc.ConnectionScope;
 import com.hivemq.client.internal.mqtt.message.connect.MqttConnect;
@@ -96,9 +94,13 @@ public class MqttChannelInitializer extends ChannelInboundHandlerAdapter {
 
     void initChannel(final @NotNull Channel channel) throws Exception {
         final MqttClientTransportConfigImpl transportConfig = connAckFlow.getTransportConfig();
+        final MqttProxyConfigImpl proxyConfig = transportConfig.getRawProxyConfig();
+        if (proxyConfig != null) {
+            MqttProxyInitializer.initChannel(channel, proxyConfig);
+        }
         final MqttClientSslConfigImpl sslConfig = transportConfig.getRawSslConfig();
         if (sslConfig != null) {
-            SslUtil.initChannel(channel, sslConfig, transportConfig.getServerAddress());
+            SslInitializer.initChannel(channel, sslConfig, transportConfig.getServerAddress());
         }
         final MqttWebSocketConfigImpl webSocketConfig = transportConfig.getRawWebSocketConfig();
         if (webSocketConfig != null) {

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/auth/MqttReAuthHandler.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/auth/MqttReAuthHandler.java
@@ -158,8 +158,7 @@ public class MqttReAuthHandler extends AbstractMqttAuthHandler {
         }
         if (state != MqttAuthState.NONE) {
             MqttDisconnectUtil.disconnect(ctx.channel(), Mqtt5DisconnectReasonCode.PROTOCOL_ERROR,
-                    new Mqtt5AuthException(
-                            auth,
+                    new Mqtt5AuthException(auth,
                             "Must not receive AUTH with reason code REAUTHENTICATE if reauth is still pending."));
             return;
         }

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/proxy/MqttProxyInitializer.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/proxy/MqttProxyInitializer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 dc-square and the HiveMQ MQTT Client Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hivemq.client.internal.mqtt.handler.proxy;
+
+import com.hivemq.client.internal.mqtt.MqttProxyConfigImpl;
+import io.netty.channel.Channel;
+import io.netty.handler.proxy.HttpProxyHandler;
+import io.netty.handler.proxy.ProxyHandler;
+import io.netty.handler.proxy.Socks4ProxyHandler;
+import io.netty.handler.proxy.Socks5ProxyHandler;
+import org.jetbrains.annotations.NotNull;
+
+import java.net.InetSocketAddress;
+
+/**
+ * @author Silvio Giebl
+ */
+public class MqttProxyInitializer {
+
+    private static final @NotNull String PROXY_HANDLER_NAME = "proxy";
+
+    public static void initChannel(final @NotNull Channel channel, final @NotNull MqttProxyConfigImpl proxyConfig) {
+        final InetSocketAddress address = proxyConfig.getProxyAddress();
+        final String username = proxyConfig.getRawProxyUsername();
+        final String password = proxyConfig.getRawProxyPassword();
+
+        final ProxyHandler proxyHandler;
+        switch (proxyConfig.getProxyType()) {
+            case SOCKS_4:
+                proxyHandler = new Socks4ProxyHandler(address, username);
+                break;
+            case SOCKS_5:
+                proxyHandler = new Socks5ProxyHandler(address, username, password);
+                break;
+            case HTTP:
+                if ((username == null) && (password == null)) {
+                    proxyHandler = new HttpProxyHandler(address);
+                } else {
+                    proxyHandler = new HttpProxyHandler(address, (username == null) ? "" : username,
+                            (password == null) ? "" : password);
+                }
+                break;
+            default:
+                return;
+        }
+        channel.pipeline().addLast(PROXY_HANDLER_NAME, proxyHandler);
+    }
+}

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/proxy/MqttProxyInitializer.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/proxy/MqttProxyInitializer.java
@@ -40,7 +40,7 @@ public class MqttProxyInitializer {
         final String password = proxyConfig.getRawProxyPassword();
 
         final ProxyHandler proxyHandler;
-        switch (proxyConfig.getProxyType()) {
+        switch (proxyConfig.getProxyProtocol()) {
             case SOCKS_4:
                 proxyHandler = new Socks4ProxyHandler(address, username);
                 break;

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttOutgoingQosHandler.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttOutgoingQosHandler.java
@@ -116,8 +116,7 @@ public class MqttOutgoingQosHandler extends MqttSessionAwareHandler
         super.onSessionStartOrResume(connectionConfig, eventLoop);
 
         final int oldSendMaximum = sendMaximum;
-        final int newSendMaximum = Math.min(
-                connectionConfig.getSendMaximum(),
+        final int newSendMaximum = Math.min(connectionConfig.getSendMaximum(),
                 UnsignedDataTypes.UNSIGNED_SHORT_MAX_VALUE - MqttSubscriptionHandler.MAX_SUB_PENDING);
         sendMaximum = newSendMaximum;
         packetIdentifiers.resize(newSendMaximum);
@@ -260,8 +259,7 @@ public class MqttOutgoingQosHandler extends MqttSessionAwareHandler
     private void writeQos0Publish(
             final @NotNull ChannelHandlerContext ctx, final @NotNull MqttPublishWithFlow publishWithFlow) {
 
-        ctx.write(
-                publishWithFlow.getPublish().createStateful(NO_PACKET_IDENTIFIER_QOS_0, false, topicAliasMapping),
+        ctx.write(publishWithFlow.getPublish().createStateful(NO_PACKET_IDENTIFIER_QOS_0, false, topicAliasMapping),
                 new DefaultContextPromise<>(ctx.channel(), publishWithFlow)).addListener(this);
     }
 
@@ -291,8 +289,7 @@ public class MqttOutgoingQosHandler extends MqttSessionAwareHandler
         pendingIndex.put(publishWithFlow);
         pending.add(publishWithFlow);
 
-        writeQos1Or2Publish(
-                ctx,
+        writeQos1Or2Publish(ctx,
                 publishWithFlow.getPublish().createStateful(packetIdentifier, false, topicAliasMapping),
                 publishWithFlow);
     }

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/ssl/MqttSslInitializer.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/ssl/MqttSslInitializer.java
@@ -30,7 +30,7 @@ import java.net.InetSocketAddress;
  * @author Christoph Schäbel
  * @author Silvio Giebl
  */
-public final class SslInitializer {
+public final class MqttSslInitializer {
 
     private static final @NotNull String SSL_HANDLER_NAME = "ssl";
 
@@ -71,5 +71,5 @@ public final class SslInitializer {
         };
     }
 
-    private SslInitializer() {}
+    private MqttSslInitializer() {}
 }

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/ssl/SslInitializer.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/ssl/SslInitializer.java
@@ -30,7 +30,7 @@ import java.net.InetSocketAddress;
  * @author Christoph Schäbel
  * @author Silvio Giebl
  */
-public final class SslUtil {
+public final class SslInitializer {
 
     private static final @NotNull String SSL_HANDLER_NAME = "ssl";
 
@@ -38,7 +38,7 @@ public final class SslUtil {
             final @NotNull Channel channel, final @NotNull MqttClientSslConfigImpl sslConfig,
             final @NotNull InetSocketAddress address) throws SSLException {
 
-        channel.pipeline().addFirst(SSL_HANDLER_NAME, createSslHandler(channel, sslConfig, address));
+        channel.pipeline().addLast(SSL_HANDLER_NAME, createSslHandler(channel, sslConfig, address));
     }
 
     private static @NotNull SslHandler createSslHandler(
@@ -71,5 +71,5 @@ public final class SslUtil {
         };
     }
 
-    private SslUtil() {}
+    private SslInitializer() {}
 }

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/MqttMessageWithUserProperties.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/MqttMessageWithUserProperties.java
@@ -114,7 +114,7 @@ public abstract class MqttMessageWithUserProperties implements MqttMessage.WithU
                 return reasonCode;
             }
 
-            protected boolean partialEquals(final @NotNull WithCode that) {
+            protected boolean partialEquals(final @NotNull WithCode<R> that) {
                 return super.partialEquals(that) && reasonCode.equals(that.reasonCode);
             }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3RxClientViewBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3RxClientViewBuilder.java
@@ -44,7 +44,7 @@ public class Mqtt3RxClientViewBuilder extends MqttRxClientBuilderBase<Mqtt3RxCli
 
     public Mqtt3RxClientViewBuilder() {}
 
-    public Mqtt3RxClientViewBuilder(final @NotNull MqttRxClientBuilderBase clientBuilder) {
+    public Mqtt3RxClientViewBuilder(final @NotNull MqttRxClientBuilderBase<?> clientBuilder) {
         super(clientBuilder);
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/MqttClientTransportConfig.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttClientTransportConfig.java
@@ -64,6 +64,12 @@ public interface MqttClientTransportConfig {
     @NotNull Optional<MqttWebSocketConfig> getWebSocketConfig();
 
     /**
+     * @return the optional proxy configuration.
+     * @since 1.2
+     */
+    @NotNull Optional<MqttProxyConfig> getProxyConfig();
+
+    /**
      * Creates a builder for extending this transport configuration.
      *
      * @return the created builder.

--- a/src/main/java/com/hivemq/client/mqtt/MqttClientTransportConfigBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttClientTransportConfigBuilderBase.java
@@ -177,4 +177,26 @@ public interface MqttClientTransportConfigBuilderBase<B extends MqttClientTransp
      */
     @CheckReturnValue
     @NotNull MqttWebSocketConfigBuilder.Nested<? extends B> webSocketConfig();
+
+    /**
+     * Sets the optional {@link MqttClientTransportConfig#getProxyConfig() proxy configuration}.
+     *
+     * @param proxyConfig the proxy configuration or <code>null</code> to remove any previously set proxy
+     *                    configuration.
+     * @return the builder.
+     * @since 1.2
+     */
+    @NotNull B proxyConfig(@Nullable MqttProxyConfig proxyConfig);
+
+    /**
+     * Fluent counterpart of {@link #proxyConfig(MqttProxyConfig)}.
+     * <p>
+     * Calling {@link MqttProxyConfigBuilder.Nested#applyProxyConfig()} on the returned builder has the effect of
+     * extending the current proxy configuration.
+     *
+     * @return the fluent builder for the proxy configuration.
+     * @see #proxyConfig(MqttProxyConfig)
+     * @since 1.2
+     */
+    @NotNull MqttProxyConfigBuilder.Nested<? extends B> proxyConfig();
 }

--- a/src/main/java/com/hivemq/client/mqtt/MqttClientTransportConfigBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttClientTransportConfigBuilderBase.java
@@ -186,6 +186,7 @@ public interface MqttClientTransportConfigBuilderBase<B extends MqttClientTransp
      * @return the builder.
      * @since 1.2
      */
+    @CheckReturnValue
     @NotNull B proxyConfig(@Nullable MqttProxyConfig proxyConfig);
 
     /**
@@ -198,5 +199,6 @@ public interface MqttClientTransportConfigBuilderBase<B extends MqttClientTransp
      * @see #proxyConfig(MqttProxyConfig)
      * @since 1.2
      */
+    @CheckReturnValue
     @NotNull MqttProxyConfigBuilder.Nested<? extends B> proxyConfig();
 }

--- a/src/main/java/com/hivemq/client/mqtt/MqttProxyConfig.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttProxyConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 dc-square and the HiveMQ MQTT Client Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hivemq.client.mqtt;
+
+import com.hivemq.client.annotations.DoNotImplement;
+import com.hivemq.client.internal.mqtt.MqttProxyConfigImplBuilder;
+import org.jetbrains.annotations.NotNull;
+
+import java.net.InetSocketAddress;
+import java.util.Optional;
+
+/**
+ * @author Silvio Giebl
+ * @since 1.2
+ */
+@DoNotImplement
+public interface MqttProxyConfig {
+
+    @NotNull MqttProxyType DEFAULT_PROXY_TYPE = MqttProxyType.SOCKS_5;
+    @NotNull String DEFAULT_PROXY_HOST = "localhost";
+    int DEFAULT_SOCKS_PROXY_PORT = 1080;
+    int DEFAULT_HTTP_PROXY_PORT = 80;
+
+    static @NotNull MqttProxyConfigBuilder builder() {
+        return new MqttProxyConfigImplBuilder.Default();
+    }
+
+    @NotNull MqttProxyType getProxyType();
+
+    @NotNull InetSocketAddress getProxyAddress();
+
+    @NotNull Optional<String> getProxyUsername();
+
+    @NotNull Optional<String> getProxyPassword();
+
+    @NotNull MqttProxyConfigBuilder extend();
+}

--- a/src/main/java/com/hivemq/client/mqtt/MqttProxyConfig.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttProxyConfig.java
@@ -25,28 +25,64 @@ import java.net.InetSocketAddress;
 import java.util.Optional;
 
 /**
+ * Configuration for a proxy to use by {@link MqttClient MQTT clients}.
+ *
  * @author Silvio Giebl
  * @since 1.2
  */
 @DoNotImplement
 public interface MqttProxyConfig {
 
-    @NotNull MqttProxyType DEFAULT_PROXY_TYPE = MqttProxyType.SOCKS_5;
+    /**
+     * The default proxy protocol.
+     */
+    @NotNull MqttProxyProtocol DEFAULT_PROXY_PROTOCOL = MqttProxyProtocol.SOCKS_5;
+    /**
+     * The default proxy host.
+     */
     @NotNull String DEFAULT_PROXY_HOST = "localhost";
+    /**
+     * The default SOCKS proxy port.
+     */
     int DEFAULT_SOCKS_PROXY_PORT = 1080;
+    /**
+     * The default HTTP proxy port.
+     */
     int DEFAULT_HTTP_PROXY_PORT = 80;
 
+    /**
+     * Creates a builder for a proxy configuration.
+     *
+     * @return the created builder for a proxy configuration.
+     */
     static @NotNull MqttProxyConfigBuilder builder() {
         return new MqttProxyConfigImplBuilder.Default();
     }
 
-    @NotNull MqttProxyType getProxyType();
+    /**
+     * @return the proxy protocol.
+     */
+    @NotNull MqttProxyProtocol getProxyProtocol();
 
+    /**
+     * @return the proxy address to connect to.
+     */
     @NotNull InetSocketAddress getProxyAddress();
 
+    /**
+     * @return the optional proxy username.
+     */
     @NotNull Optional<String> getProxyUsername();
 
+    /**
+     * @return the optional proxy password.
+     */
     @NotNull Optional<String> getProxyPassword();
 
+    /**
+     * Creates a builder for extending this proxy configuration.
+     *
+     * @return the created builder.
+     */
     @NotNull MqttProxyConfigBuilder extend();
 }

--- a/src/main/java/com/hivemq/client/mqtt/MqttProxyConfigBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttProxyConfigBuilder.java
@@ -21,17 +21,34 @@ import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
 /**
+ * Builder for a {@link MqttProxyConfig}.
+ *
  * @author Silvio Giebl
  * @since 1.2
  */
 @DoNotImplement
 public interface MqttProxyConfigBuilder extends MqttProxyConfigBuilderBase<MqttProxyConfigBuilder> {
 
+    /**
+     * Builds the {@link MqttProxyConfig}.
+     *
+     * @return the built {@link MqttProxyConfig}.
+     */
     @NotNull MqttProxyConfig build();
 
+    /**
+     * Builder for a {@link MqttProxyConfig} that is applied to a parent.
+     *
+     * @param <P> the type of the result when the built {@link MqttProxyConfig} is applied to the parent.
+     */
     @DoNotImplement
     interface Nested<P> extends MqttProxyConfigBuilderBase<Nested<P>> {
 
+        /**
+         * Builds the {@link MqttProxyConfig} and applies it to the parent.
+         *
+         * @return the result when the built {@link MqttProxyConfig} is applied to the parent.
+         */
         @NotNull P applyProxyConfig();
     }
 }

--- a/src/main/java/com/hivemq/client/mqtt/MqttProxyConfigBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttProxyConfigBuilder.java
@@ -15,19 +15,23 @@
  *
  */
 
-package com.hivemq.client.internal.mqtt;
+package com.hivemq.client.mqtt;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
-import org.junit.jupiter.api.Test;
+import com.hivemq.client.annotations.DoNotImplement;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * @author Silvio Giebl
+ * @since 1.2
  */
-class MqttWebSocketConfigImplTest {
+@DoNotImplement
+public interface MqttProxyConfigBuilder extends MqttProxyConfigBuilderBase<MqttProxyConfigBuilder> {
 
-    @Test
-    void equals() {
-        EqualsVerifier.forClass(MqttWebSocketConfigImpl.class).suppress(Warning.STRICT_INHERITANCE).verify();
+    @NotNull MqttProxyConfig build();
+
+    @DoNotImplement
+    interface Nested<P> extends MqttProxyConfigBuilderBase<Nested<P>> {
+
+        @NotNull P applyProxyConfig();
     }
 }

--- a/src/main/java/com/hivemq/client/mqtt/MqttProxyConfigBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttProxyConfigBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,6 +35,7 @@ public interface MqttProxyConfigBuilder extends MqttProxyConfigBuilderBase<MqttP
      *
      * @return the built {@link MqttProxyConfig}.
      */
+    @CheckReturnValue
     @NotNull MqttProxyConfig build();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/MqttProxyConfigBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttProxyConfigBuilderBase.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 dc-square and the HiveMQ MQTT Client Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hivemq.client.mqtt;
+
+import com.hivemq.client.annotations.DoNotImplement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+/**
+ * @author Silvio Giebl
+ * @since 1.2
+ */
+@DoNotImplement
+public interface MqttProxyConfigBuilderBase<B extends MqttProxyConfigBuilderBase<B>> {
+
+    @NotNull B proxyType(@NotNull MqttProxyType type);
+
+    @NotNull B proxyAddress(@NotNull InetSocketAddress address);
+
+    @NotNull B proxyHost(@NotNull String host);
+
+    @NotNull B proxyHost(@NotNull InetAddress host);
+
+    @NotNull B proxyPort(int port);
+
+    @NotNull B proxyUsername(@Nullable String username);
+
+    @NotNull B proxyPassword(@Nullable String password);
+}

--- a/src/main/java/com/hivemq/client/mqtt/MqttProxyConfigBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttProxyConfigBuilderBase.java
@@ -25,23 +25,67 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
 /**
+ * Builder base for a {@link MqttProxyConfig}.
+ *
  * @author Silvio Giebl
  * @since 1.2
  */
 @DoNotImplement
 public interface MqttProxyConfigBuilderBase<B extends MqttProxyConfigBuilderBase<B>> {
 
-    @NotNull B proxyType(@NotNull MqttProxyType type);
+    /**
+     * Sets the {@link MqttProxyConfig#getProxyProtocol() proxy protocol}.
+     *
+     * @param protocol the proxy protocol.
+     * @return the builder.
+     */
+    @NotNull B proxyProtocol(@NotNull MqttProxyProtocol protocol);
 
+    /**
+     * Sets the {@link MqttProxyConfig#getProxyAddress() proxy address} to connect to.
+     *
+     * @param address the proxy address.
+     * @return the builder.
+     */
     @NotNull B proxyAddress(@NotNull InetSocketAddress address);
 
+    /**
+     * Sets the proxy host to connect to.
+     *
+     * @param host the proxy host.
+     * @return the builder.
+     */
     @NotNull B proxyHost(@NotNull String host);
 
+    /**
+     * Sets the proxy host to connect to.
+     *
+     * @param host the proxy host.
+     * @return the builder.
+     */
     @NotNull B proxyHost(@NotNull InetAddress host);
 
+    /**
+     * Sets the proxy port to connect to.
+     *
+     * @param port the proxy port.
+     * @return the builder.
+     */
     @NotNull B proxyPort(int port);
 
+    /**
+     * Sets the {@link MqttProxyConfig#getProxyUsername() proxy username}.
+     *
+     * @param username the proxy username.
+     * @return the builder.
+     */
     @NotNull B proxyUsername(@Nullable String username);
 
+    /**
+     * Sets the {@link MqttProxyConfig#getProxyPassword() proxy password}.
+     *
+     * @param password the proxy username.
+     * @return the builder.
+     */
     @NotNull B proxyPassword(@Nullable String password);
 }

--- a/src/main/java/com/hivemq/client/mqtt/MqttProxyConfigBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttProxyConfigBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -39,6 +40,7 @@ public interface MqttProxyConfigBuilderBase<B extends MqttProxyConfigBuilderBase
      * @param protocol the proxy protocol.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B proxyProtocol(@NotNull MqttProxyProtocol protocol);
 
     /**
@@ -47,6 +49,7 @@ public interface MqttProxyConfigBuilderBase<B extends MqttProxyConfigBuilderBase
      * @param address the proxy address.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B proxyAddress(@NotNull InetSocketAddress address);
 
     /**
@@ -55,6 +58,7 @@ public interface MqttProxyConfigBuilderBase<B extends MqttProxyConfigBuilderBase
      * @param host the proxy host.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B proxyHost(@NotNull String host);
 
     /**
@@ -63,6 +67,7 @@ public interface MqttProxyConfigBuilderBase<B extends MqttProxyConfigBuilderBase
      * @param host the proxy host.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B proxyHost(@NotNull InetAddress host);
 
     /**
@@ -71,6 +76,7 @@ public interface MqttProxyConfigBuilderBase<B extends MqttProxyConfigBuilderBase
      * @param port the proxy port.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B proxyPort(int port);
 
     /**
@@ -79,6 +85,7 @@ public interface MqttProxyConfigBuilderBase<B extends MqttProxyConfigBuilderBase
      * @param username the proxy username.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B proxyUsername(@Nullable String username);
 
     /**
@@ -87,5 +94,6 @@ public interface MqttProxyConfigBuilderBase<B extends MqttProxyConfigBuilderBase
      * @param password the proxy username.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B proxyPassword(@Nullable String password);
 }

--- a/src/main/java/com/hivemq/client/mqtt/MqttProxyProtocol.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttProxyProtocol.java
@@ -18,12 +18,23 @@
 package com.hivemq.client.mqtt;
 
 /**
+ * Available proxy protocols for a {@link MqttProxyConfig}.
+ *
  * @author Silvio Giebl
  * @since 1.2
  */
-public enum MqttProxyType {
+public enum MqttProxyProtocol {
 
+    /**
+     * SOCKS4 proxy protocol.
+     */
     SOCKS_4,
+    /**
+     * SOCKS5 proxy protocol.
+     */
     SOCKS_5,
+    /**
+     * HTTP CONNECT proxy protocol.
+     */
     HTTP
 }

--- a/src/main/java/com/hivemq/client/mqtt/MqttProxyType.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttProxyType.java
@@ -15,19 +15,15 @@
  *
  */
 
-package com.hivemq.client.internal.mqtt;
-
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
-import org.junit.jupiter.api.Test;
+package com.hivemq.client.mqtt;
 
 /**
  * @author Silvio Giebl
+ * @since 1.2
  */
-class MqttWebSocketConfigImplTest {
+public enum MqttProxyType {
 
-    @Test
-    void equals() {
-        EqualsVerifier.forClass(MqttWebSocketConfigImpl.class).suppress(Warning.STRICT_INHERITANCE).verify();
-    }
+    SOCKS_4,
+    SOCKS_5,
+    HTTP
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5PayloadFormatIndicator.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5PayloadFormatIndicator.java
@@ -32,7 +32,8 @@ public enum Mqtt5PayloadFormatIndicator {
      */
     UNSPECIFIED,
     /**
-     * Payload consists of UTF-8 encoded character data as defined by the Unicode specification and restated in RFC 3629.
+     * Payload consists of UTF-8 encoded character data as defined by the Unicode specification and restated in RFC
+     * 3629.
      */
     UTF_8;
 

--- a/src/test/java/com/hivemq/client/internal/mqtt/MqttClientTransportConfigImplTest.java
+++ b/src/test/java/com/hivemq/client/internal/mqtt/MqttClientTransportConfigImplTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 dc-square and the HiveMQ MQTT Client Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hivemq.client.internal.mqtt;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * @author Silvio Giebl
+ */
+class MqttClientTransportConfigImplTest {
+
+    @Test
+    void equals() throws NoSuchAlgorithmException {
+        final KeyManagerFactory kmf1 = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        final KeyManagerFactory kmf2 = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        final TrustManagerFactory tmf1 = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        final TrustManagerFactory tmf2 = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+
+        EqualsVerifier.forClass(MqttClientTransportConfigImpl.class)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .withIgnoredAnnotations(NotNull.class) // EqualsVerifier thinks @NotNull Optional is @NotNull
+                .withNonnullFields("serverAddress")
+                .withPrefabValues(KeyManagerFactory.class, kmf1, kmf2)
+                .withPrefabValues(TrustManagerFactory.class, tmf1, tmf2)
+                .verify();
+    }
+}

--- a/src/test/java/com/hivemq/client/internal/mqtt/MqttProxyConfigImplTest.java
+++ b/src/test/java/com/hivemq/client/internal/mqtt/MqttProxyConfigImplTest.java
@@ -32,7 +32,7 @@ class MqttProxyConfigImplTest {
         EqualsVerifier.forClass(MqttProxyConfigImpl.class)
                 .suppress(Warning.STRICT_INHERITANCE)
                 .withIgnoredAnnotations(NotNull.class) // EqualsVerifier thinks @NotNull Optional is @NotNull
-                .withNonnullFields("type", "address")
+                .withNonnullFields("protocol", "address")
                 .verify();
     }
 }

--- a/src/test/java/com/hivemq/client/internal/mqtt/MqttProxyConfigImplTest.java
+++ b/src/test/java/com/hivemq/client/internal/mqtt/MqttProxyConfigImplTest.java
@@ -19,15 +19,20 @@ package com.hivemq.client.internal.mqtt;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 /**
  * @author Silvio Giebl
  */
-class MqttWebSocketConfigImplTest {
+class MqttProxyConfigImplTest {
 
     @Test
     void equals() {
-        EqualsVerifier.forClass(MqttWebSocketConfigImpl.class).suppress(Warning.STRICT_INHERITANCE).verify();
+        EqualsVerifier.forClass(MqttProxyConfigImpl.class)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .withIgnoredAnnotations(NotNull.class) // EqualsVerifier thinks @NotNull Optional is @NotNull
+                .withNonnullFields("type", "address")
+                .verify();
     }
 }

--- a/src/test/java/com/hivemq/client/internal/mqtt/handler/ssl/MqttSslInitializerTest.java
+++ b/src/test/java/com/hivemq/client/internal/mqtt/handler/ssl/MqttSslInitializerTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * @author Christoph Schäbel
  */
-class SslInitializerTest {
+class MqttSslInitializerTest {
 
     @SuppressWarnings("NullabilityAnnotations")
     private EmbeddedChannel embeddedChannel;
@@ -183,6 +183,6 @@ class SslInitializerTest {
     private static @NotNull SSLEngine createSslEngine(
             final @NotNull Channel channel, final @NotNull MqttClientSslConfigImpl sslConfig) throws SSLException {
 
-        return SslInitializer.createSslContext(sslConfig).newEngine(channel.alloc());
+        return MqttSslInitializer.createSslContext(sslConfig).newEngine(channel.alloc());
     }
 }

--- a/src/test/java/com/hivemq/client/internal/mqtt/handler/ssl/SslInitializerTest.java
+++ b/src/test/java/com/hivemq/client/internal/mqtt/handler/ssl/SslInitializerTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * @author Christoph Schäbel
  */
-class SslUtilTest {
+class SslInitializerTest {
 
     @SuppressWarnings("NullabilityAnnotations")
     private EmbeddedChannel embeddedChannel;
@@ -183,6 +183,6 @@ class SslUtilTest {
     private static @NotNull SSLEngine createSslEngine(
             final @NotNull Channel channel, final @NotNull MqttClientSslConfigImpl sslConfig) throws SSLException {
 
-        return SslUtil.createSslContext(sslConfig).newEngine(channel.alloc());
+        return SslInitializer.createSslContext(sslConfig).newEngine(channel.alloc());
     }
 }


### PR DESCRIPTION
**Motivation**
Resolves #81 
Resolves #281 

**Changes**
- Added proxy support: SOCKS4, SOCKS5, HTTP CONNECT
- Make netty-codec-http, netty-handler-proxy, netty-transport-native-epoll optional dependencies
- Add explicit dependencies for netty instead of relying on transitive dependencies of netty-handler
- Added missing equals/hashCode methods to TransportConfig