### PR TITLE
Added CheckReturnValue annotation to all builder methods

### DIFF
--- a/src/main/java/com/hivemq/client/annotations/CheckReturnValue.java
+++ b/src/main/java/com/hivemq/client/annotations/CheckReturnValue.java
@@ -15,28 +15,16 @@
  *
  */
 
-package com.hivemq.client.mqtt.datatypes;
+package com.hivemq.client.annotations;
 
-import com.hivemq.client.annotations.CheckReturnValue;
-import com.hivemq.client.annotations.DoNotImplement;
-import org.jetbrains.annotations.NotNull;
+import java.lang.annotation.*;
 
 /**
- * Builder base for a {@link MqttTopic}.
+ * Documents that the return value of a method should not be ignored.
  *
- * @param <C> the type of the complete builder.
  * @author Silvio Giebl
- * @since 1.0
  */
-@DoNotImplement
-public interface MqttTopicBuilderBase<C extends MqttTopicBuilderBase<C>> {
-
-    /**
-     * Adds a {@link MqttTopic#getLevels() Topic level}.
-     *
-     * @param topicLevel the level.
-     * @return the builder that is now complete as at least one Topic level is set.
-     */
-    @CheckReturnValue
-    @NotNull C addLevel(@NotNull String topicLevel);
-}
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.METHOD)
+public @interface CheckReturnValue {}

--- a/src/main/java/com/hivemq/client/mqtt/MqttClientBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttClientBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.mqtt3.Mqtt3ClientBuilder;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5ClientBuilder;
@@ -36,6 +37,7 @@ public interface MqttClientBuilder extends MqttClientBuilderBase<MqttClientBuild
      *
      * @return the builder for the {@link com.hivemq.client.mqtt.mqtt3.Mqtt3Client Mqtt3Client}.
      */
+    @CheckReturnValue
     @NotNull Mqtt3ClientBuilder useMqttVersion3();
 
     /**
@@ -43,5 +45,6 @@ public interface MqttClientBuilder extends MqttClientBuilderBase<MqttClientBuild
      *
      * @return the builder for the {@link com.hivemq.client.mqtt.mqtt5.Mqtt5Client Mqtt5Client}.
      */
+    @CheckReturnValue
     @NotNull Mqtt5ClientBuilder useMqttVersion5();
 }

--- a/src/main/java/com/hivemq/client/mqtt/MqttClientBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttClientBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.datatypes.MqttClientIdentifier;
 import com.hivemq.client.mqtt.lifecycle.MqttClientAutoReconnect;
@@ -45,6 +46,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @param identifier the string representation of the Client Identifier.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B identifier(@NotNull String identifier);
 
     /**
@@ -53,6 +55,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @param identifier the Client Identifier.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B identifier(@NotNull MqttClientIdentifier identifier);
 
     /**
@@ -62,6 +65,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @return the builder
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull B serverAddress(@NotNull InetSocketAddress address);
 
     /**
@@ -70,6 +74,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @param host the server host.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B serverHost(@NotNull String host);
 
     /**
@@ -79,6 +84,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @return the builder.
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull B serverHost(@NotNull InetAddress host);
 
     /**
@@ -87,6 +93,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @param port the server port.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B serverPort(int port);
 
     /**
@@ -105,6 +112,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @return the builder.
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull B sslWithDefaultConfig();
 
     /**
@@ -123,6 +131,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @return the builder.
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull B sslConfig(@Nullable MqttClientSslConfig sslConfig);
 
     /**
@@ -143,6 +152,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @see #sslConfig(MqttClientSslConfig)
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull MqttClientSslConfigBuilder.Nested<? extends B> sslConfig();
 
     /**
@@ -160,6 +170,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @return the builder.
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull B webSocketWithDefaultConfig();
 
     /**
@@ -178,6 +189,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @return the builder.
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull B webSocketConfig(@Nullable MqttWebSocketConfig webSocketConfig);
 
     /**
@@ -198,6 +210,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @see #webSocketConfig(MqttWebSocketConfig)
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull MqttWebSocketConfigBuilder.Nested<? extends B> webSocketConfig();
 
     /**
@@ -207,6 +220,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @return the builder.
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull B transportConfig(@NotNull MqttClientTransportConfig transportConfig);
 
     /**
@@ -219,6 +233,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @see #transportConfig(MqttClientTransportConfig)
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull MqttClientTransportConfigBuilder.Nested<? extends B> transportConfig();
 
     /**
@@ -227,6 +242,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @param executorConfig the executor configuration.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B executorConfig(@NotNull MqttClientExecutorConfig executorConfig);
 
     /**
@@ -238,6 +254,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @return the fluent builder for the executor configuration.
      * @see #executorConfig(MqttClientExecutorConfig)
      */
+    @CheckReturnValue
     @NotNull MqttClientExecutorConfigBuilder.Nested<? extends B> executorConfig();
 
     /**
@@ -246,6 +263,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @return the builder.
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull B automaticReconnectWithDefaultConfig();
 
     /**
@@ -256,6 +274,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @return the builder.
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull B automaticReconnect(@Nullable MqttClientAutoReconnect autoReconnect);
 
     /**
@@ -268,6 +287,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @see #automaticReconnect(MqttClientAutoReconnect)
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull MqttClientAutoReconnectBuilder.Nested<? extends B> automaticReconnect();
 
     /**
@@ -279,6 +299,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @return the builder.
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull B addConnectedListener(@NotNull MqttClientConnectedListener connectedListener);
 
     /**
@@ -291,5 +312,6 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @return the builder.
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull B addDisconnectedListener(@NotNull MqttClientDisconnectedListener disconnectedListener);
 }

--- a/src/main/java/com/hivemq/client/mqtt/MqttClientExecutorConfigBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttClientExecutorConfigBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -35,6 +36,7 @@ public interface MqttClientExecutorConfigBuilder
      *
      * @return the built {@link MqttClientExecutorConfig}.
      */
+    @CheckReturnValue
     @NotNull MqttClientExecutorConfig build();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/MqttClientExecutorConfigBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttClientExecutorConfigBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import io.reactivex.Scheduler;
 import org.jetbrains.annotations.NotNull;
@@ -41,6 +42,7 @@ public interface MqttClientExecutorConfigBuilderBase<B extends MqttClientExecuto
      * @param nettyExecutor the user defined executor for Netty or <code>null</code> to use the default executor.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B nettyExecutor(@Nullable Executor nettyExecutor);
 
     /**
@@ -50,6 +52,7 @@ public interface MqttClientExecutorConfigBuilderBase<B extends MqttClientExecuto
      * @param nettyThreads the user defined amount of threads Netty.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B nettyThreads(int nettyThreads);
 
     /**
@@ -59,5 +62,6 @@ public interface MqttClientExecutorConfigBuilderBase<B extends MqttClientExecuto
      * @param applicationScheduler the scheduler used for executing application specific code.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B applicationScheduler(@NotNull Scheduler applicationScheduler);
 }

--- a/src/main/java/com/hivemq/client/mqtt/MqttClientSslConfigBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttClientSslConfigBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,6 +35,7 @@ public interface MqttClientSslConfigBuilder extends MqttClientSslConfigBuilderBa
      *
      * @return the built {@link MqttClientSslConfig}.
      */
+    @CheckReturnValue
     @NotNull MqttClientSslConfig build();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/MqttClientSslConfigBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttClientSslConfigBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -43,6 +44,7 @@ public interface MqttClientSslConfigBuilderBase<B extends MqttClientSslConfigBui
      *                          factory.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B keyManagerFactory(@Nullable KeyManagerFactory keyManagerFactory);
 
     /**
@@ -52,6 +54,7 @@ public interface MqttClientSslConfigBuilderBase<B extends MqttClientSslConfigBui
      *                            manager factory
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B trustManagerFactory(@Nullable TrustManagerFactory trustManagerFactory);
 
     /**
@@ -61,6 +64,7 @@ public interface MqttClientSslConfigBuilderBase<B extends MqttClientSslConfigBui
      *                     communication framework).
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B cipherSuites(@Nullable Collection<@NotNull String> cipherSuites);
 
     /**
@@ -70,6 +74,7 @@ public interface MqttClientSslConfigBuilderBase<B extends MqttClientSslConfigBui
      *                  framework).
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B protocols(@Nullable Collection<@NotNull String> protocols);
 
     /**
@@ -79,5 +84,6 @@ public interface MqttClientSslConfigBuilderBase<B extends MqttClientSslConfigBui
      * @param timeUnit the time unit of the given timeout.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B handshakeTimeout(long timeout, @NotNull TimeUnit timeUnit);
 }

--- a/src/main/java/com/hivemq/client/mqtt/MqttClientTransportConfigBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttClientTransportConfigBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -35,6 +36,7 @@ public interface MqttClientTransportConfigBuilder
      *
      * @return the built {@link MqttClientTransportConfig}.
      */
+    @CheckReturnValue
     @NotNull MqttClientTransportConfig build();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/MqttClientTransportConfigBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttClientTransportConfigBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -39,6 +40,7 @@ public interface MqttClientTransportConfigBuilderBase<B extends MqttClientTransp
      * @param address the server address.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B serverAddress(@NotNull InetSocketAddress address);
 
     /**
@@ -47,6 +49,7 @@ public interface MqttClientTransportConfigBuilderBase<B extends MqttClientTransp
      * @param host the server host.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B serverHost(@NotNull String host);
 
     /**
@@ -55,6 +58,7 @@ public interface MqttClientTransportConfigBuilderBase<B extends MqttClientTransp
      * @param host the server host.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B serverHost(@NotNull InetAddress host);
 
     /**
@@ -63,6 +67,7 @@ public interface MqttClientTransportConfigBuilderBase<B extends MqttClientTransp
      * @param port the server port.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B serverPort(int port);
 
     /**
@@ -73,6 +78,7 @@ public interface MqttClientTransportConfigBuilderBase<B extends MqttClientTransp
      *
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B sslWithDefaultConfig();
 
     /**
@@ -82,6 +88,7 @@ public interface MqttClientTransportConfigBuilderBase<B extends MqttClientTransp
      *                  transport configuration.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B sslConfig(@Nullable MqttClientSslConfig sslConfig);
 
     /**
@@ -93,6 +100,7 @@ public interface MqttClientTransportConfigBuilderBase<B extends MqttClientTransp
      * @return the fluent builder for the secure transport configuration.
      * @see #sslConfig(MqttClientSslConfig)
      */
+    @CheckReturnValue
     @NotNull MqttClientSslConfigBuilder.Nested<? extends B> sslConfig();
 
     /**
@@ -101,6 +109,7 @@ public interface MqttClientTransportConfigBuilderBase<B extends MqttClientTransp
      *
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B webSocketWithDefaultConfig();
 
     /**
@@ -110,6 +119,7 @@ public interface MqttClientTransportConfigBuilderBase<B extends MqttClientTransp
      *                        WebSocket transport configuration.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B webSocketConfig(@Nullable MqttWebSocketConfig webSocketConfig);
 
     /**
@@ -121,5 +131,6 @@ public interface MqttClientTransportConfigBuilderBase<B extends MqttClientTransp
      * @return the fluent builder for the WebSocket configuration.
      * @see #webSocketConfig(MqttWebSocketConfig)
      */
+    @CheckReturnValue
     @NotNull MqttWebSocketConfigBuilder.Nested<? extends B> webSocketConfig();
 }

--- a/src/main/java/com/hivemq/client/mqtt/MqttWebSocketConfigBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttWebSocketConfigBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,6 +35,7 @@ public interface MqttWebSocketConfigBuilder extends MqttWebSocketConfigBuilderBa
      *
      * @return the built {@link MqttWebSocketConfig}.
      */
+    @CheckReturnValue
     @NotNull MqttWebSocketConfig build();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/MqttWebSocketConfigBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttWebSocketConfigBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -36,6 +37,7 @@ public interface MqttWebSocketConfigBuilderBase<B extends MqttWebSocketConfigBui
      * @param serverPath the server path.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B serverPath(@NotNull String serverPath);
 
     /**
@@ -52,5 +54,6 @@ public interface MqttWebSocketConfigBuilderBase<B extends MqttWebSocketConfigBui
      * @param subprotocol the subprotocol.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B subprotocol(@NotNull String subprotocol);
 }

--- a/src/main/java/com/hivemq/client/mqtt/datatypes/MqttSharedTopicFilterBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/datatypes/MqttSharedTopicFilterBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.datatypes;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -56,6 +57,7 @@ public interface MqttSharedTopicFilterBuilder extends
          *
          * @return the built {@link MqttSharedTopicFilter}.
          */
+        @CheckReturnValue
         @NotNull MqttSharedTopicFilter build();
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/datatypes/MqttTopicBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/datatypes/MqttTopicBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.datatypes;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,6 +35,7 @@ public interface MqttTopicBuilder extends MqttTopicBuilderBase<MqttTopicBuilder.
      *
      * @return the created builder for a Topic Filter.
      */
+    @CheckReturnValue
     @NotNull MqttTopicFilterBuilder filter();
 
     /**
@@ -42,6 +44,7 @@ public interface MqttTopicBuilder extends MqttTopicBuilderBase<MqttTopicBuilder.
      * @param shareName the Share Name.
      * @return the created builder for a Shared Topic Filter.
      */
+    @CheckReturnValue
     @NotNull MqttSharedTopicFilterBuilder share(@NotNull String shareName);
 
     /**
@@ -55,6 +58,7 @@ public interface MqttTopicBuilder extends MqttTopicBuilderBase<MqttTopicBuilder.
          *
          * @return the built {@link MqttTopic}.
          */
+        @CheckReturnValue
         @NotNull MqttTopic build();
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/datatypes/MqttTopicFilterBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/datatypes/MqttTopicFilterBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.datatypes;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -57,6 +58,7 @@ public interface MqttTopicFilterBuilder extends
          *
          * @return the built {@link MqttTopicFilter}.
          */
+        @CheckReturnValue
         @NotNull MqttTopicFilter build();
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/datatypes/MqttTopicFilterBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/datatypes/MqttTopicFilterBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.datatypes;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -47,6 +48,7 @@ public interface MqttTopicFilterBuilderBase<
      * @param topicLevel the level.
      * @return the builder that is now complete as at least one Topic level is set.
      */
+    @CheckReturnValue
     @NotNull C addLevel(@NotNull String topicLevel);
 
     /**
@@ -54,6 +56,7 @@ public interface MqttTopicFilterBuilderBase<
      *
      * @return the builder that is now complete as at least one single-level wildcard is set.
      */
+    @CheckReturnValue
     @NotNull C singleLevelWildcard();
 
     /**
@@ -61,6 +64,7 @@ public interface MqttTopicFilterBuilderBase<
      *
      * @return the end builder.
      */
+    @CheckReturnValue
     @NotNull E multiLevelWildcard();
 
     /**
@@ -69,6 +73,7 @@ public interface MqttTopicFilterBuilderBase<
      * @param shareName the Share Name.
      * @return the created builder for a Shared Topic Filter.
      */
+    @CheckReturnValue
     @NotNull S share(@NotNull String shareName);
 
     /**
@@ -98,6 +103,7 @@ public interface MqttTopicFilterBuilderBase<
          * @return the created complete builder for a Shared Topic Filter.
          */
         @Override
+        @CheckReturnValue
         @NotNull SC share(@NotNull String shareName);
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/lifecycle/MqttClientAutoReconnectBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/lifecycle/MqttClientAutoReconnectBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.lifecycle;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -35,6 +36,7 @@ public interface MqttClientAutoReconnectBuilder
      *
      * @return the built {@link MqttClientAutoReconnect}.
      */
+    @CheckReturnValue
     @NotNull MqttClientAutoReconnect build();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/lifecycle/MqttClientAutoReconnectBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/lifecycle/MqttClientAutoReconnectBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.lifecycle;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -40,6 +41,7 @@ public interface MqttClientAutoReconnectBuilderBase<B extends MqttClientAutoReco
      * @param timeUnit     the time unit of the given initial delay.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B initialDelay(final long initialDelay, @NotNull TimeUnit timeUnit);
 
     /**
@@ -51,5 +53,6 @@ public interface MqttClientAutoReconnectBuilderBase<B extends MqttClientAutoReco
      * @param timeUnit the time unit of the given maximum delay.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B maxDelay(final long maxDelay, @NotNull TimeUnit timeUnit);
 }

--- a/src/main/java/com/hivemq/client/mqtt/lifecycle/MqttClientReconnector.java
+++ b/src/main/java/com/hivemq/client/mqtt/lifecycle/MqttClientReconnector.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.lifecycle;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.MqttClientTransportConfig;
 import com.hivemq.client.mqtt.MqttClientTransportConfigBuilder;
@@ -117,6 +118,7 @@ public interface MqttClientReconnector {
      * @return the fluent builder for the transport configuration.
      * @see #transportConfig(MqttClientTransportConfig)
      */
+    @CheckReturnValue
     @NotNull MqttClientTransportConfigBuilder.Nested<? extends MqttClientReconnector> transportConfig();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3AsyncClient.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3AsyncClient.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.internal.mqtt.message.connect.mqtt3.Mqtt3ConnectView;
 import com.hivemq.client.internal.mqtt.message.connect.mqtt3.Mqtt3ConnectViewBuilder;
@@ -84,6 +85,7 @@ public interface Mqtt3AsyncClient extends Mqtt3Client {
      * @return the fluent builder for the Connect message.
      * @see #connect(Mqtt3Connect)
      */
+    @CheckReturnValue
     default @NotNull Mqtt3ConnectBuilder.Send<CompletableFuture<Mqtt3ConnAck>> connectWith() {
         return new Mqtt3ConnectViewBuilder.Send<>(this::connect);
     }
@@ -157,6 +159,7 @@ public interface Mqtt3AsyncClient extends Mqtt3Client {
      * @see #subscribe(Mqtt3Subscribe, Consumer)
      * @see #subscribe(Mqtt3Subscribe, Consumer, Executor)
      */
+    @CheckReturnValue
     default @NotNull Mqtt3SubscribeAndCallbackBuilder.Start subscribeWith() {
         return new Mqtt3AsyncClientView.Mqtt3SubscribeViewAndCallbackBuilder(this);
     }
@@ -204,6 +207,7 @@ public interface Mqtt3AsyncClient extends Mqtt3Client {
      * @return the fluent builder for the Unsubscribe message.
      * @see #unsubscribe(Mqtt3Unsubscribe)
      */
+    @CheckReturnValue
     default @NotNull Mqtt3UnsubscribeBuilder.Send.Start<CompletableFuture<Void>> unsubscribeWith() {
         return new Mqtt3UnsubscribeViewBuilder.Send<>(this::unsubscribe);
     }
@@ -231,6 +235,7 @@ public interface Mqtt3AsyncClient extends Mqtt3Client {
      * @return the fluent builder for the Unsubscribe message.
      * @see #publish(Mqtt3Publish)
      */
+    @CheckReturnValue
     default @NotNull Mqtt3PublishBuilder.Send<CompletableFuture<Mqtt3Publish>> publishWith() {
         return new Mqtt3PublishViewBuilder.Send<>(this::publish);
     }
@@ -285,6 +290,7 @@ public interface Mqtt3AsyncClient extends Mqtt3Client {
         @DoNotImplement
         interface Call {
 
+            @CheckReturnValue
             @NotNull Ex callback(@NotNull Consumer<Mqtt3Publish> callback);
 
             @NotNull CompletableFuture<Mqtt3SubAck> send();
@@ -292,6 +298,7 @@ public interface Mqtt3AsyncClient extends Mqtt3Client {
             @DoNotImplement
             interface Ex extends Call {
 
+                @CheckReturnValue
                 @NotNull Ex executor(@NotNull Executor executor);
             }
         }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3BlockingClient.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3BlockingClient.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.internal.mqtt.message.connect.mqtt3.Mqtt3ConnectView;
 import com.hivemq.client.internal.mqtt.message.connect.mqtt3.Mqtt3ConnectViewBuilder;
@@ -77,6 +78,7 @@ public interface Mqtt3BlockingClient extends Mqtt3Client {
      * @return the fluent builder for the Connect message.
      * @see #connect(Mqtt3Connect)
      */
+    @CheckReturnValue
     default @NotNull Mqtt3ConnectBuilder.Send<Mqtt3ConnAck> connectWith() {
         return new Mqtt3ConnectViewBuilder.Send<>(this::connect);
     }
@@ -103,6 +105,7 @@ public interface Mqtt3BlockingClient extends Mqtt3Client {
      * @return the fluent builder for the Subscribe message.
      * @see #subscribe(Mqtt3Subscribe)
      */
+    @CheckReturnValue
     default @NotNull Mqtt3SubscribeBuilder.Send.Start<Mqtt3SubAck> subscribeWith() {
         return new Mqtt3SubscribeViewBuilder.Send<>(this::subscribe);
     }
@@ -132,6 +135,7 @@ public interface Mqtt3BlockingClient extends Mqtt3Client {
      * @return the fluent builder for the Unsubscribe message.
      * @see #unsubscribe(Mqtt3Unsubscribe)
      */
+    @CheckReturnValue
     default @NotNull Mqtt3UnsubscribeBuilder.SendVoid.Start unsubscribeWith() {
         return new Mqtt3UnsubscribeViewBuilder.SendVoid(this::unsubscribe);
     }
@@ -152,6 +156,7 @@ public interface Mqtt3BlockingClient extends Mqtt3Client {
      * @return the fluent builder for the Unsubscribe message.
      * @see #publish(Mqtt3Publish)
      */
+    @CheckReturnValue
     default @NotNull Mqtt3PublishBuilder.SendVoid publishWith() {
         return new Mqtt3PublishViewBuilder.SendVoid(this::publish);
     }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3Client.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3Client.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.internal.mqtt.mqtt3.Mqtt3RxClientViewBuilder;
 import com.hivemq.client.mqtt.MqttClient;
@@ -50,6 +51,7 @@ public interface Mqtt3Client extends MqttClient {
      *
      * @return a reactive API for this client.
      */
+    @CheckReturnValue
     @NotNull Mqtt3RxClient toRx();
 
     /**
@@ -59,6 +61,7 @@ public interface Mqtt3Client extends MqttClient {
      *
      * @return a asynchronous API for this client.
      */
+    @CheckReturnValue
     @NotNull Mqtt3AsyncClient toAsync();
 
     /**
@@ -68,5 +71,6 @@ public interface Mqtt3Client extends MqttClient {
      *
      * @return a blocking API for this client.
      */
+    @CheckReturnValue
     @NotNull Mqtt3BlockingClient toBlocking();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3ClientBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3ClientBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.MqttClientBuilderBase;
 import com.hivemq.client.mqtt.mqtt3.message.auth.Mqtt3SimpleAuth;
@@ -44,6 +45,7 @@ public interface Mqtt3ClientBuilder extends MqttClientBuilderBase<Mqtt3ClientBui
      * @return the builder.
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull Mqtt3ClientBuilder simpleAuth(@Nullable Mqtt3SimpleAuth simpleAuth);
 
     /**
@@ -57,6 +59,7 @@ public interface Mqtt3ClientBuilder extends MqttClientBuilderBase<Mqtt3ClientBui
      * @see #simpleAuth(Mqtt3SimpleAuth)
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull Mqtt3SimpleAuthBuilder.Nested<? extends Mqtt3ClientBuilder> simpleAuth();
 
     /**
@@ -66,6 +69,7 @@ public interface Mqtt3ClientBuilder extends MqttClientBuilderBase<Mqtt3ClientBui
      * @return the builder.
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull Mqtt3ClientBuilder willPublish(@Nullable Mqtt3Publish willPublish);
 
     /**
@@ -79,6 +83,7 @@ public interface Mqtt3ClientBuilder extends MqttClientBuilderBase<Mqtt3ClientBui
      * @see #willPublish(Mqtt3Publish)
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull Mqtt3WillPublishBuilder.Nested<? extends Mqtt3ClientBuilder> willPublish();
 
     /**
@@ -86,6 +91,7 @@ public interface Mqtt3ClientBuilder extends MqttClientBuilderBase<Mqtt3ClientBui
      *
      * @return the built {@link Mqtt3Client}.
      */
+    @CheckReturnValue
     @NotNull Mqtt3Client build();
 
     /**
@@ -93,6 +99,7 @@ public interface Mqtt3ClientBuilder extends MqttClientBuilderBase<Mqtt3ClientBui
      *
      * @return the built {@link Mqtt3RxClient}.
      */
+    @CheckReturnValue
     @NotNull Mqtt3RxClient buildRx();
 
     /**
@@ -100,6 +107,7 @@ public interface Mqtt3ClientBuilder extends MqttClientBuilderBase<Mqtt3ClientBui
      *
      * @return the built {@link Mqtt3AsyncClient}.
      */
+    @CheckReturnValue
     @NotNull Mqtt3AsyncClient buildAsync();
 
     /**
@@ -107,5 +115,6 @@ public interface Mqtt3ClientBuilder extends MqttClientBuilderBase<Mqtt3ClientBui
      *
      * @return the built {@link Mqtt3BlockingClient}.
      */
+    @CheckReturnValue
     @NotNull Mqtt3BlockingClient buildBlocking();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3RxClient.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3RxClient.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.internal.mqtt.message.connect.mqtt3.Mqtt3ConnectView;
 import com.hivemq.client.internal.mqtt.message.connect.mqtt3.Mqtt3ConnectViewBuilder;
@@ -87,6 +88,7 @@ public interface Mqtt3RxClient extends Mqtt3Client {
      * @return the fluent builder for the Connect message.
      * @see #connect(Mqtt3Connect)
      */
+    @CheckReturnValue
     default @NotNull Mqtt3ConnectBuilder.Nested<Single<Mqtt3ConnAck>> connectWith() {
         return new Mqtt3ConnectViewBuilder.Nested<>(this::connect);
     }
@@ -125,6 +127,7 @@ public interface Mqtt3RxClient extends Mqtt3Client {
      * @return the fluent builder for the Subscribe message.
      * @see #subscribe(Mqtt3Subscribe)
      */
+    @CheckReturnValue
     default @NotNull Mqtt3SubscribeBuilder.Nested.Start<Single<Mqtt3SubAck>> subscribeWith() {
         return new Mqtt3SubscribeViewBuilder.Nested<>(this::subscribe);
     }
@@ -165,6 +168,7 @@ public interface Mqtt3RxClient extends Mqtt3Client {
      * @return the fluent builder for the Subscribe message.
      * @see #subscribeStream(Mqtt3Subscribe)
      */
+    @CheckReturnValue
     default @NotNull Mqtt3SubscribeBuilder.Nested.Start<FlowableWithSingle<Mqtt3Publish, Mqtt3SubAck>> subscribeStreamWith() {
         return new Mqtt3SubscribeViewBuilder.Nested<>(this::subscribeStream);
     }
@@ -214,6 +218,7 @@ public interface Mqtt3RxClient extends Mqtt3Client {
      * @return the fluent builder for the Unsubscribe message.
      * @see #unsubscribe(Mqtt3Unsubscribe)
      */
+    @CheckReturnValue
     default @NotNull Mqtt3UnsubscribeBuilder.Nested.Start<Completable> unsubscribeWith() {
         return new Mqtt3UnsubscribeViewBuilder.Nested<>(this::unsubscribe);
     }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/lifecycle/Mqtt3ClientReconnector.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/lifecycle/Mqtt3ClientReconnector.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3.lifecycle;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.MqttClientTransportConfig;
 import com.hivemq.client.mqtt.MqttClientTransportConfigBuilder;
@@ -54,6 +55,7 @@ public interface Mqtt3ClientReconnector extends MqttClientReconnector {
     @NotNull Mqtt3ClientReconnector transportConfig(@NotNull MqttClientTransportConfig transportConfig);
 
     @Override
+    @CheckReturnValue
     @NotNull MqttClientTransportConfigBuilder.Nested<? extends Mqtt3ClientReconnector> transportConfig();
 
     /**
@@ -73,6 +75,7 @@ public interface Mqtt3ClientReconnector extends MqttClientReconnector {
      * @return the fluent builder for the Connect message.
      * @see #connect(Mqtt3Connect)
      */
+    @CheckReturnValue
     @NotNull Mqtt3ConnectBuilder.Nested<? extends Mqtt3ClientReconnector> connectWith();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/auth/Mqtt3SimpleAuthBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/auth/Mqtt3SimpleAuthBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3.message.auth;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -41,6 +42,7 @@ public interface Mqtt3SimpleAuthBuilder extends Mqtt3SimpleAuthBuilderBase<Mqtt3
          *
          * @return the built {@link Mqtt3SimpleAuth}.
          */
+        @CheckReturnValue
         @NotNull Mqtt3SimpleAuth build();
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/auth/Mqtt3SimpleAuthBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/auth/Mqtt3SimpleAuthBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3.message.auth;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.datatypes.MqttUtf8String;
 import org.jetbrains.annotations.NotNull;
@@ -39,6 +40,7 @@ public interface Mqtt3SimpleAuthBuilderBase<C extends Mqtt3SimpleAuthBuilderBase
      * @param username the username string.
      * @return the builder that is now complete as the mandatory username is set.
      */
+    @CheckReturnValue
     @NotNull C username(@NotNull String username);
 
     /**
@@ -47,6 +49,7 @@ public interface Mqtt3SimpleAuthBuilderBase<C extends Mqtt3SimpleAuthBuilderBase
      * @param username the username string.
      * @return the builder that is now complete as the mandatory username is set.
      */
+    @CheckReturnValue
     @NotNull C username(@NotNull MqttUtf8String username);
 
     /**
@@ -63,6 +66,7 @@ public interface Mqtt3SimpleAuthBuilderBase<C extends Mqtt3SimpleAuthBuilderBase
          * @param password the password as byte array.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C password(@NotNull byte[] password);
 
         /**
@@ -71,6 +75,7 @@ public interface Mqtt3SimpleAuthBuilderBase<C extends Mqtt3SimpleAuthBuilderBase
          * @param password the password as {@link ByteBuffer}.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C password(@NotNull ByteBuffer password);
     }
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3.message.connect;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,6 +35,7 @@ public interface Mqtt3ConnectBuilder extends Mqtt3ConnectBuilderBase<Mqtt3Connec
      *
      * @return the built {@link Mqtt3Connect}.
      */
+    @CheckReturnValue
     @NotNull Mqtt3Connect build();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3.message.connect;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.mqtt3.message.auth.Mqtt3SimpleAuth;
 import com.hivemq.client.mqtt.mqtt3.message.auth.Mqtt3SimpleAuthBuilder;
@@ -43,6 +44,7 @@ public interface Mqtt3ConnectBuilderBase<B extends Mqtt3ConnectBuilderBase<B>> {
      * @param keepAlive the keep alive in seconds.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B keepAlive(int keepAlive);
 
     /**
@@ -50,6 +52,7 @@ public interface Mqtt3ConnectBuilderBase<B extends Mqtt3ConnectBuilderBase<B>> {
      *
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B noKeepAlive();
 
     /**
@@ -58,6 +61,7 @@ public interface Mqtt3ConnectBuilderBase<B extends Mqtt3ConnectBuilderBase<B>> {
      * @param cleanSession whether the client connects with a clean session.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B cleanSession(boolean cleanSession);
 
     /**
@@ -67,6 +71,7 @@ public interface Mqtt3ConnectBuilderBase<B extends Mqtt3ConnectBuilderBase<B>> {
      *                   related data.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B simpleAuth(@Nullable Mqtt3SimpleAuth simpleAuth);
 
     /**
@@ -79,6 +84,7 @@ public interface Mqtt3ConnectBuilderBase<B extends Mqtt3ConnectBuilderBase<B>> {
      * @return the fluent builder for the simple auth related data.
      * @see #simpleAuth(Mqtt3SimpleAuth)
      */
+    @CheckReturnValue
     @NotNull Mqtt3SimpleAuthBuilder.Nested<? extends B> simpleAuth();
 
     /**
@@ -87,6 +93,7 @@ public interface Mqtt3ConnectBuilderBase<B extends Mqtt3ConnectBuilderBase<B>> {
      * @param willPublish the Will Publish or <code>null</code> to remove any previously set Will Publish.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B willPublish(@Nullable Mqtt3Publish willPublish);
 
     /**
@@ -99,5 +106,6 @@ public interface Mqtt3ConnectBuilderBase<B extends Mqtt3ConnectBuilderBase<B>> {
      * @return the fluent builder for the Will Publish.
      * @see #willPublish(Mqtt3Publish)
      */
+    @CheckReturnValue
     @NotNull Mqtt3WillPublishBuilder.Nested<? extends B> willPublish();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/publish/Mqtt3PublishBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/publish/Mqtt3PublishBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3.message.publish;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -40,6 +41,7 @@ public interface Mqtt3PublishBuilder extends Mqtt3PublishBuilderBase<Mqtt3Publis
          *
          * @return the built {@link Mqtt3Publish}.
          */
+        @CheckReturnValue
         @NotNull Mqtt3Publish build();
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/publish/Mqtt3PublishBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/publish/Mqtt3PublishBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3.message.publish;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.datatypes.MqttTopic;
@@ -42,6 +43,7 @@ public interface Mqtt3PublishBuilderBase<C extends Mqtt3PublishBuilderBase.Compl
      * @param topic the string representation of the Topic.
      * @return the builder that is now complete as the mandatory Topic is set.
      */
+    @CheckReturnValue
     @NotNull C topic(@NotNull String topic);
 
     /**
@@ -50,6 +52,7 @@ public interface Mqtt3PublishBuilderBase<C extends Mqtt3PublishBuilderBase.Compl
      * @param topic the Topic.
      * @return the builder that is now complete as the mandatory Topic is set.
      */
+    @CheckReturnValue
     @NotNull C topic(@NotNull MqttTopic topic);
 
     /**
@@ -61,6 +64,7 @@ public interface Mqtt3PublishBuilderBase<C extends Mqtt3PublishBuilderBase.Compl
      * @return the fluent builder for the Topic.
      * @see #topic(MqttTopic)
      */
+    @CheckReturnValue
     @NotNull MqttTopicBuilder.Nested<? extends C> topic();
 
     /**
@@ -77,6 +81,7 @@ public interface Mqtt3PublishBuilderBase<C extends Mqtt3PublishBuilderBase.Compl
          * @param payload the payload as byte array or <code>null</code> to remove any previously set payload.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C payload(@Nullable byte[] payload);
 
         /**
@@ -85,6 +90,7 @@ public interface Mqtt3PublishBuilderBase<C extends Mqtt3PublishBuilderBase.Compl
          * @param payload the payload as {@link ByteBuffer} or <code>null</code> to remove any previously set payload.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C payload(@Nullable ByteBuffer payload);
 
         /**
@@ -93,6 +99,7 @@ public interface Mqtt3PublishBuilderBase<C extends Mqtt3PublishBuilderBase.Compl
          * @param qos the QoS.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C qos(@NotNull MqttQos qos);
 
         /**
@@ -101,6 +108,7 @@ public interface Mqtt3PublishBuilderBase<C extends Mqtt3PublishBuilderBase.Compl
          * @param retain whether the Publish message should be retained.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C retain(boolean retain);
     }
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/publish/Mqtt3WillPublishBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/publish/Mqtt3WillPublishBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3.message.publish;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -41,6 +42,7 @@ public interface Mqtt3WillPublishBuilder extends Mqtt3PublishBuilderBase<Mqtt3Wi
          *
          * @return the built {@link Mqtt3Publish}.
          */
+        @CheckReturnValue
         @NotNull Mqtt3Publish build();
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3.message.subscribe;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -40,6 +41,7 @@ public interface Mqtt3SubscribeBuilder extends Mqtt3SubscribeBuilderBase<Mqtt3Su
          *
          * @return the built {@link Mqtt3Subscribe}.
          */
+        @CheckReturnValue
         @NotNull Mqtt3Subscribe build();
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3.message.subscribe;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -40,6 +41,7 @@ public interface Mqtt3SubscribeBuilderBase<C extends Mqtt3SubscribeBuilderBase<C
      * @param subscription the subscription.
      * @return the builder that is now complete as at least one subscription is set.
      */
+    @CheckReturnValue
     @NotNull C addSubscription(@NotNull Mqtt3Subscription subscription);
 
     /**
@@ -52,6 +54,7 @@ public interface Mqtt3SubscribeBuilderBase<C extends Mqtt3SubscribeBuilderBase<C
      * @return the fluent builder for the subscription.
      * @see #addSubscription(Mqtt3Subscription)
      */
+    @CheckReturnValue
     @NotNull Mqtt3SubscriptionBuilder.Nested<? extends C> addSubscription();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3.message.subscribe;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -41,6 +42,7 @@ public interface Mqtt3SubscriptionBuilder extends Mqtt3SubscriptionBuilderBase<M
          *
          * @return the built {@link Mqtt3Subscription}.
          */
+        @CheckReturnValue
         @NotNull Mqtt3Subscription build();
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3.message.subscribe;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.datatypes.MqttTopicFilter;
@@ -39,6 +40,7 @@ public interface Mqtt3SubscriptionBuilderBase<C extends Mqtt3SubscriptionBuilder
      * @param topicFilter the string representation of the Topic Filter.
      * @return the builder that is now complete as the mandatory Topic Filter is set.
      */
+    @CheckReturnValue
     @NotNull C topicFilter(@NotNull String topicFilter);
 
     /**
@@ -47,6 +49,7 @@ public interface Mqtt3SubscriptionBuilderBase<C extends Mqtt3SubscriptionBuilder
      * @param topicFilter the Topic Filter.
      * @return the builder that is now complete as the mandatory Topic Filter is set.
      */
+    @CheckReturnValue
     @NotNull C topicFilter(@NotNull MqttTopicFilter topicFilter);
 
     /**
@@ -59,6 +62,7 @@ public interface Mqtt3SubscriptionBuilderBase<C extends Mqtt3SubscriptionBuilder
      * @return the fluent builder for the Topic Filter.
      * @see #topicFilter(MqttTopicFilter)
      */
+    @CheckReturnValue
     @NotNull MqttTopicFilterBuilder.Nested<? extends C> topicFilter();
 
     /**
@@ -75,6 +79,7 @@ public interface Mqtt3SubscriptionBuilderBase<C extends Mqtt3SubscriptionBuilder
          * @param qos the QoS.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C qos(@NotNull MqttQos qos);
     }
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3.message.unsubscribe;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -40,6 +41,7 @@ public interface Mqtt3UnsubscribeBuilder extends Mqtt3UnsubscribeBuilderBase<Mqt
          *
          * @return the built {@link Mqtt3Unsubscribe}.
          */
+        @CheckReturnValue
         @NotNull Mqtt3Unsubscribe build();
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt3.message.unsubscribe;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.datatypes.MqttTopicFilter;
 import com.hivemq.client.mqtt.datatypes.MqttTopicFilterBuilder;
@@ -43,6 +44,7 @@ public interface Mqtt3UnsubscribeBuilderBase<C extends Mqtt3UnsubscribeBuilderBa
      * @param topicFilter the string representation of the Topic Filter.
      * @return the builder that is now complete as at least one Topic Filter is set.
      */
+    @CheckReturnValue
     @NotNull C addTopicFilter(@NotNull String topicFilter);
 
     /**
@@ -52,6 +54,7 @@ public interface Mqtt3UnsubscribeBuilderBase<C extends Mqtt3UnsubscribeBuilderBa
      * @param topicFilter the Topic Filter.
      * @return the builder that is now complete as at least one Topic Filter is set.
      */
+    @CheckReturnValue
     @NotNull C addTopicFilter(@NotNull MqttTopicFilter topicFilter);
 
     /**
@@ -64,6 +67,7 @@ public interface Mqtt3UnsubscribeBuilderBase<C extends Mqtt3UnsubscribeBuilderBa
      * @return the fluent builder for the Topic Filter.
      * @see #addTopicFilter(MqttTopicFilter)
      */
+    @CheckReturnValue
     @NotNull MqttTopicFilterBuilder.Nested<? extends C> addTopicFilter();
 
     /**
@@ -102,6 +106,7 @@ public interface Mqtt3UnsubscribeBuilderBase<C extends Mqtt3UnsubscribeBuilderBa
      * @param subscribe the Subscribe message.
      * @return the builder that is now complete as at least one Topic Filter is set.
      */
+    @CheckReturnValue
     @NotNull C reverse(@NotNull Mqtt3Subscribe subscribe);
 
     /**
@@ -118,6 +123,7 @@ public interface Mqtt3UnsubscribeBuilderBase<C extends Mqtt3UnsubscribeBuilderBa
          * @param topicFilter the string representation of the Topic Filter.
          * @return the builder that is now complete as the mandatory Topic Filter is set.
          */
+        @CheckReturnValue
         @NotNull C topicFilter(@NotNull String topicFilter);
 
         /**
@@ -126,6 +132,7 @@ public interface Mqtt3UnsubscribeBuilderBase<C extends Mqtt3UnsubscribeBuilderBa
          * @param topicFilter the Topic Filter.
          * @return the builder that is now complete as the mandatory Topic Filter is set.
          */
+        @CheckReturnValue
         @NotNull C topicFilter(@NotNull MqttTopicFilter topicFilter);
 
         /**
@@ -138,6 +145,7 @@ public interface Mqtt3UnsubscribeBuilderBase<C extends Mqtt3UnsubscribeBuilderBa
          * @return the fluent builder for the Topic Filter.
          * @see #addTopicFilter(MqttTopicFilter)
          */
+        @CheckReturnValue
         @NotNull MqttTopicFilterBuilder.Nested<? extends C> topicFilter();
     }
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5AsyncClient.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5AsyncClient.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.internal.mqtt.MqttAsyncClient;
 import com.hivemq.client.internal.mqtt.message.connect.MqttConnect;
@@ -90,6 +91,7 @@ public interface Mqtt5AsyncClient extends Mqtt5Client {
      * @return the fluent builder for the Connect message.
      * @see #connect(Mqtt5Connect)
      */
+    @CheckReturnValue
     default @NotNull Mqtt5ConnectBuilder.Send<CompletableFuture<Mqtt5ConnAck>> connectWith() {
         return new MqttConnectBuilder.Send<>(this::connect);
     }
@@ -163,6 +165,7 @@ public interface Mqtt5AsyncClient extends Mqtt5Client {
      * @see #subscribe(Mqtt5Subscribe, Consumer)
      * @see #subscribe(Mqtt5Subscribe, Consumer, Executor)
      */
+    @CheckReturnValue
     default @NotNull Mqtt5SubscribeAndCallbackBuilder.Start subscribeWith() {
         return new MqttAsyncClient.MqttSubscribeAndCallbackBuilder(this);
     }
@@ -213,6 +216,7 @@ public interface Mqtt5AsyncClient extends Mqtt5Client {
      * @return the fluent builder for the Unsubscribe message.
      * @see #unsubscribe(Mqtt5Unsubscribe)
      */
+    @CheckReturnValue
     default @NotNull Mqtt5UnsubscribeBuilder.Send.Start<CompletableFuture<Mqtt5UnsubAck>> unsubscribeWith() {
         return new MqttUnsubscribeBuilder.Send<>(this::unsubscribe);
     }
@@ -244,6 +248,7 @@ public interface Mqtt5AsyncClient extends Mqtt5Client {
      * @return the fluent builder for the Unsubscribe message.
      * @see #publish(Mqtt5Publish)
      */
+    @CheckReturnValue
     default @NotNull Mqtt5PublishBuilder.Send<CompletableFuture<Mqtt5PublishResult>> publishWith() {
         return new MqttPublishBuilder.Send<>(this::publish);
     }
@@ -294,6 +299,7 @@ public interface Mqtt5AsyncClient extends Mqtt5Client {
      * @return the fluent builder for the Unsubscribe message.
      * @see #disconnect(Mqtt5Disconnect)
      */
+    @CheckReturnValue
     default @NotNull Mqtt5DisconnectBuilder.Send<CompletableFuture<Void>> disconnectWith() {
         return new MqttDisconnectBuilder.Send<>(this::disconnect);
     }
@@ -337,6 +343,7 @@ public interface Mqtt5AsyncClient extends Mqtt5Client {
         @DoNotImplement
         interface Call {
 
+            @CheckReturnValue
             @NotNull Ex callback(@NotNull Consumer<Mqtt5Publish> callback);
 
             @NotNull CompletableFuture<Mqtt5SubAck> send();
@@ -344,6 +351,7 @@ public interface Mqtt5AsyncClient extends Mqtt5Client {
             @DoNotImplement
             interface Ex extends Call {
 
+                @CheckReturnValue
                 @NotNull Ex executor(@NotNull Executor executor);
             }
         }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5BlockingClient.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5BlockingClient.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.internal.mqtt.message.connect.MqttConnect;
 import com.hivemq.client.internal.mqtt.message.connect.MqttConnectBuilder;
@@ -83,6 +84,7 @@ public interface Mqtt5BlockingClient extends Mqtt5Client {
      * @return the fluent builder for the Connect message.
      * @see #connect(Mqtt5Connect)
      */
+    @CheckReturnValue
     default @NotNull Mqtt5ConnectBuilder.Send<Mqtt5ConnAck> connectWith() {
         return new MqttConnectBuilder.Send<>(this::connect);
     }
@@ -109,6 +111,7 @@ public interface Mqtt5BlockingClient extends Mqtt5Client {
      * @return the fluent builder for the Subscribe message.
      * @see #subscribe(Mqtt5Subscribe)
      */
+    @CheckReturnValue
     default @NotNull Mqtt5SubscribeBuilder.Send.Start<Mqtt5SubAck> subscribeWith() {
         return new MqttSubscribeBuilder.Send<>(this::subscribe);
     }
@@ -142,6 +145,7 @@ public interface Mqtt5BlockingClient extends Mqtt5Client {
      * @return the fluent builder for the Unsubscribe message.
      * @see #unsubscribe(Mqtt5Unsubscribe)
      */
+    @CheckReturnValue
     default @NotNull Mqtt5UnsubscribeBuilder.Send.Start<Mqtt5UnsubAck> unsubscribeWith() {
         return new MqttUnsubscribeBuilder.Send<>(this::unsubscribe);
     }
@@ -168,6 +172,7 @@ public interface Mqtt5BlockingClient extends Mqtt5Client {
      * @return the fluent builder for the Unsubscribe message.
      * @see #publish(Mqtt5Publish)
      */
+    @CheckReturnValue
     default @NotNull Mqtt5PublishBuilder.Send<Mqtt5PublishResult> publishWith() {
         return new MqttPublishBuilder.Send<>(this::publish);
     }
@@ -205,6 +210,7 @@ public interface Mqtt5BlockingClient extends Mqtt5Client {
      * @return the fluent builder for the Unsubscribe message.
      * @see #disconnect(Mqtt5Disconnect)
      */
+    @CheckReturnValue
     default @NotNull Mqtt5DisconnectBuilder.SendVoid disconnectWith() {
         return new MqttDisconnectBuilder.SendVoid(this::disconnect);
     }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5Client.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5Client.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.internal.mqtt.MqttRxClientBuilder;
 import com.hivemq.client.mqtt.MqttClient;
@@ -50,6 +51,7 @@ public interface Mqtt5Client extends MqttClient {
      *
      * @return a reactive API for this client.
      */
+    @CheckReturnValue
     @NotNull Mqtt5RxClient toRx();
 
     /**
@@ -59,6 +61,7 @@ public interface Mqtt5Client extends MqttClient {
      *
      * @return a asynchronous API for this client.
      */
+    @CheckReturnValue
     @NotNull Mqtt5AsyncClient toAsync();
 
     /**
@@ -68,5 +71,6 @@ public interface Mqtt5Client extends MqttClient {
      *
      * @return a blocking API for this client.
      */
+    @CheckReturnValue
     @NotNull Mqtt5BlockingClient toBlocking();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5ClientBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5ClientBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.MqttClientBuilderBase;
 import com.hivemq.client.mqtt.mqtt5.advanced.Mqtt5ClientAdvancedConfig;
@@ -44,6 +45,7 @@ public interface Mqtt5ClientBuilder extends MqttClientBuilderBase<Mqtt5ClientBui
      * @param advancedConfig the advanced configuration.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull Mqtt5ClientBuilder advancedConfig(@NotNull Mqtt5ClientAdvancedConfig advancedConfig);
 
     /**
@@ -55,6 +57,7 @@ public interface Mqtt5ClientBuilder extends MqttClientBuilderBase<Mqtt5ClientBui
      * @return the fluent builder for the advanced configuration.
      * @see #advancedConfig(Mqtt5ClientAdvancedConfig)
      */
+    @CheckReturnValue
     @NotNull Mqtt5ClientAdvancedConfigBuilder.Nested<? extends Mqtt5ClientBuilder> advancedConfig();
 
     /**
@@ -66,6 +69,7 @@ public interface Mqtt5ClientBuilder extends MqttClientBuilderBase<Mqtt5ClientBui
      * @return the builder.
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull Mqtt5ClientBuilder simpleAuth(@Nullable Mqtt5SimpleAuth simpleAuth);
 
     /**
@@ -79,6 +83,7 @@ public interface Mqtt5ClientBuilder extends MqttClientBuilderBase<Mqtt5ClientBui
      * @see #simpleAuth(Mqtt5SimpleAuth)
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull Mqtt5SimpleAuthBuilder.Nested<? extends Mqtt5ClientBuilder> simpleAuth();
 
     /**
@@ -90,6 +95,7 @@ public interface Mqtt5ClientBuilder extends MqttClientBuilderBase<Mqtt5ClientBui
      * @return the builder.
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull Mqtt5ClientBuilder enhancedAuth(@Nullable Mqtt5EnhancedAuthMechanism enhancedAuthMechanism);
 
     /**
@@ -99,6 +105,7 @@ public interface Mqtt5ClientBuilder extends MqttClientBuilderBase<Mqtt5ClientBui
      * @return the builder.
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull Mqtt5ClientBuilder willPublish(@Nullable Mqtt5Publish willPublish);
 
     /**
@@ -112,6 +119,7 @@ public interface Mqtt5ClientBuilder extends MqttClientBuilderBase<Mqtt5ClientBui
      * @see #willPublish(Mqtt5Publish)
      * @since 1.1
      */
+    @CheckReturnValue
     @NotNull Mqtt5WillPublishBuilder.Nested<? extends Mqtt5ClientBuilder> willPublish();
 
     /**
@@ -119,6 +127,7 @@ public interface Mqtt5ClientBuilder extends MqttClientBuilderBase<Mqtt5ClientBui
      *
      * @return the built {@link Mqtt5Client}.
      */
+    @CheckReturnValue
     @NotNull Mqtt5Client build();
 
     /**
@@ -126,6 +135,7 @@ public interface Mqtt5ClientBuilder extends MqttClientBuilderBase<Mqtt5ClientBui
      *
      * @return the built {@link Mqtt5RxClient}.
      */
+    @CheckReturnValue
     @NotNull Mqtt5RxClient buildRx();
 
     /**
@@ -133,6 +143,7 @@ public interface Mqtt5ClientBuilder extends MqttClientBuilderBase<Mqtt5ClientBui
      *
      * @return the built {@link Mqtt5AsyncClient}.
      */
+    @CheckReturnValue
     @NotNull Mqtt5AsyncClient buildAsync();
 
     /**
@@ -140,5 +151,6 @@ public interface Mqtt5ClientBuilder extends MqttClientBuilderBase<Mqtt5ClientBui
      *
      * @return the built {@link Mqtt5BlockingClient}.
      */
+    @CheckReturnValue
     @NotNull Mqtt5BlockingClient buildBlocking();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5RxClient.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5RxClient.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.internal.mqtt.message.connect.MqttConnect;
 import com.hivemq.client.internal.mqtt.message.connect.MqttConnectBuilder;
@@ -92,6 +93,7 @@ public interface Mqtt5RxClient extends Mqtt5Client {
      * @return the fluent builder for the Connect message.
      * @see #connect(Mqtt5Connect)
      */
+    @CheckReturnValue
     default @NotNull Mqtt5ConnectBuilder.Nested<Single<Mqtt5ConnAck>> connectWith() {
         return new MqttConnectBuilder.Nested<>(this::connect);
     }
@@ -130,6 +132,7 @@ public interface Mqtt5RxClient extends Mqtt5Client {
      * @return the fluent builder for the Subscribe message.
      * @see #subscribe(Mqtt5Subscribe)
      */
+    @CheckReturnValue
     default @NotNull Mqtt5SubscribeBuilder.Nested.Start<Single<Mqtt5SubAck>> subscribeWith() {
         return new MqttSubscribeBuilder.Nested<>(this::subscribe);
     }
@@ -170,6 +173,7 @@ public interface Mqtt5RxClient extends Mqtt5Client {
      * @return the fluent builder for the Subscribe message.
      * @see #subscribeStream(Mqtt5Subscribe)
      */
+    @CheckReturnValue
     default @NotNull Mqtt5SubscribeBuilder.Nested.Start<FlowableWithSingle<Mqtt5Publish, Mqtt5SubAck>> subscribeStreamWith() {
         return new MqttSubscribeBuilder.Nested<>(this::subscribeStream);
     }
@@ -223,6 +227,7 @@ public interface Mqtt5RxClient extends Mqtt5Client {
      * @return the fluent builder for the Unsubscribe message.
      * @see #unsubscribe(Mqtt5Unsubscribe)
      */
+    @CheckReturnValue
     default @NotNull Mqtt5UnsubscribeBuilder.Nested.Start<Single<Mqtt5UnsubAck>> unsubscribeWith() {
         return new MqttUnsubscribeBuilder.Nested<>(this::unsubscribe);
     }
@@ -300,6 +305,7 @@ public interface Mqtt5RxClient extends Mqtt5Client {
      * @return the builder for the Disconnect message.
      * @see #disconnect(Mqtt5Disconnect)
      */
+    @CheckReturnValue
     default @NotNull Mqtt5DisconnectBuilder.Nested<Completable> disconnectWith() {
         return new MqttDisconnectBuilder.Nested<>(this::disconnect);
     }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/advanced/Mqtt5ClientAdvancedConfigBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/advanced/Mqtt5ClientAdvancedConfigBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.advanced;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -35,6 +36,7 @@ public interface Mqtt5ClientAdvancedConfigBuilder
      *
      * @return the built {@link Mqtt5ClientAdvancedConfig}.
      */
+    @CheckReturnValue
     @NotNull Mqtt5ClientAdvancedConfig build();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/advanced/Mqtt5ClientAdvancedConfigBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/advanced/Mqtt5ClientAdvancedConfigBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.advanced;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.mqtt5.advanced.interceptor.Mqtt5ClientInterceptors;
 import com.hivemq.client.mqtt.mqtt5.advanced.interceptor.Mqtt5ClientInterceptorsBuilder;
@@ -39,6 +40,7 @@ public interface Mqtt5ClientAdvancedConfigBuilderBase<B extends Mqtt5ClientAdvan
      * @param allowServerReAuth whether server re-auth is allowed.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B allowServerReAuth(boolean allowServerReAuth);
 
     /**
@@ -47,6 +49,7 @@ public interface Mqtt5ClientAdvancedConfigBuilderBase<B extends Mqtt5ClientAdvan
      * @param validatePayloadFormat whether the payload format is validated.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B validatePayloadFormat(boolean validatePayloadFormat);
 
     /**
@@ -56,6 +59,7 @@ public interface Mqtt5ClientAdvancedConfigBuilderBase<B extends Mqtt5ClientAdvan
      *                     interceptors.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B interceptors(@Nullable Mqtt5ClientInterceptors interceptors);
 
     /**
@@ -67,5 +71,6 @@ public interface Mqtt5ClientAdvancedConfigBuilderBase<B extends Mqtt5ClientAdvan
      * @return the fluent builder for the collection of interceptors.
      * @see #interceptors(Mqtt5ClientInterceptors)
      */
+    @CheckReturnValue
     @NotNull Mqtt5ClientInterceptorsBuilder.Nested<? extends B> interceptors();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/advanced/interceptor/Mqtt5ClientInterceptorsBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/advanced/interceptor/Mqtt5ClientInterceptorsBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.advanced.interceptor;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -35,6 +36,7 @@ public interface Mqtt5ClientInterceptorsBuilder
      *
      * @return the built {@link Mqtt5ClientInterceptors}.
      */
+    @CheckReturnValue
     @NotNull Mqtt5ClientInterceptors build();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/advanced/interceptor/Mqtt5ClientInterceptorsBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/advanced/interceptor/Mqtt5ClientInterceptorsBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.advanced.interceptor;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.mqtt5.advanced.interceptor.qos1.Mqtt5IncomingQos1Interceptor;
 import com.hivemq.client.mqtt.mqtt5.advanced.interceptor.qos1.Mqtt5OutgoingQos1Interceptor;
@@ -35,11 +36,15 @@ import org.jetbrains.annotations.Nullable;
 @DoNotImplement
 public interface Mqtt5ClientInterceptorsBuilderBase<B extends Mqtt5ClientInterceptorsBuilderBase<B>> {
 
+    @CheckReturnValue
     @NotNull B incomingQos1Interceptor(@Nullable Mqtt5IncomingQos1Interceptor incomingQos1Interceptor);
 
+    @CheckReturnValue
     @NotNull B outgoingQos1Interceptor(@Nullable Mqtt5OutgoingQos1Interceptor outgoingQos1Interceptor);
 
+    @CheckReturnValue
     @NotNull B incomingQos2Interceptor(@Nullable Mqtt5IncomingQos2Interceptor incomingQos2Interceptor);
 
+    @CheckReturnValue
     @NotNull B outgoingQos2Interceptor(@Nullable Mqtt5OutgoingQos2Interceptor outgoingQos2Interceptor);
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/datatypes/Mqtt5UserPropertiesBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/datatypes/Mqtt5UserPropertiesBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.datatypes;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,6 +35,7 @@ public interface Mqtt5UserPropertiesBuilder extends Mqtt5UserPropertiesBuilderBa
      *
      * @return the built {@link Mqtt5UserProperties}.
      */
+    @CheckReturnValue
     @NotNull Mqtt5UserProperties build();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/datatypes/Mqtt5UserPropertiesBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/datatypes/Mqtt5UserPropertiesBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.datatypes;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.datatypes.MqttUtf8String;
 import org.jetbrains.annotations.NotNull;
@@ -41,6 +42,7 @@ public interface Mqtt5UserPropertiesBuilderBase<B extends Mqtt5UserPropertiesBui
      * @param value the value of the User Property.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B add(@NotNull String name, @NotNull String value);
 
     /**
@@ -50,6 +52,7 @@ public interface Mqtt5UserPropertiesBuilderBase<B extends Mqtt5UserPropertiesBui
      * @param value the value of the User Property.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B add(@NotNull MqttUtf8String name, @NotNull MqttUtf8String value);
 
     /**
@@ -58,6 +61,7 @@ public interface Mqtt5UserPropertiesBuilderBase<B extends Mqtt5UserPropertiesBui
      * @param userProperty the User Property.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B add(@NotNull Mqtt5UserProperty userProperty);
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/lifecycle/Mqtt5ClientReconnector.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/lifecycle/Mqtt5ClientReconnector.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.lifecycle;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.MqttClientTransportConfig;
 import com.hivemq.client.mqtt.MqttClientTransportConfigBuilder;
@@ -54,6 +55,7 @@ public interface Mqtt5ClientReconnector extends MqttClientReconnector {
     @NotNull Mqtt5ClientReconnector transportConfig(@NotNull MqttClientTransportConfig transportConfig);
 
     @Override
+    @CheckReturnValue
     @NotNull MqttClientTransportConfigBuilder.Nested<? extends Mqtt5ClientReconnector> transportConfig();
 
     /**
@@ -73,6 +75,7 @@ public interface Mqtt5ClientReconnector extends MqttClientReconnector {
      * @return the fluent builder for the Connect message.
      * @see #connect(Mqtt5Connect)
      */
+    @CheckReturnValue
     @NotNull Mqtt5ConnectBuilder.Nested<? extends Mqtt5ClientReconnector> connectWith();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/auth/Mqtt5AuthBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/auth/Mqtt5AuthBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.auth;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.datatypes.MqttUtf8String;
 import com.hivemq.client.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
@@ -74,5 +75,6 @@ public interface Mqtt5AuthBuilder extends Mqtt5EnhancedAuthBuilder {
      * @return the fluent builder for the User Properties.
      * @see #userProperties(Mqtt5UserProperties)
      */
+    @CheckReturnValue
     @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends Mqtt5AuthBuilder> userProperties();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/auth/Mqtt5SimpleAuthBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/auth/Mqtt5SimpleAuthBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.auth;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -40,6 +41,7 @@ public interface Mqtt5SimpleAuthBuilder extends Mqtt5SimpleAuthBuilderBase<Mqtt5
          *
          * @return the built {@link Mqtt5SimpleAuth}.
          */
+        @CheckReturnValue
         @NotNull Mqtt5SimpleAuth build();
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/auth/Mqtt5SimpleAuthBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/auth/Mqtt5SimpleAuthBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.auth;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.datatypes.MqttUtf8String;
 import org.jetbrains.annotations.NotNull;
@@ -39,6 +40,7 @@ public interface Mqtt5SimpleAuthBuilderBase<C extends Mqtt5SimpleAuthBuilderBase
      * @param username the username string.
      * @return the builder that is now complete as the username is set.
      */
+    @CheckReturnValue
     @NotNull C username(@NotNull String username);
 
     /**
@@ -47,6 +49,7 @@ public interface Mqtt5SimpleAuthBuilderBase<C extends Mqtt5SimpleAuthBuilderBase
      * @param username the username string.
      * @return the builder that is now complete as the username is set.
      */
+    @CheckReturnValue
     @NotNull C username(@NotNull MqttUtf8String username);
 
     /**
@@ -55,6 +58,7 @@ public interface Mqtt5SimpleAuthBuilderBase<C extends Mqtt5SimpleAuthBuilderBase
      * @param password the password as byte array.
      * @return the builder that is now complete as the password is set.
      */
+    @CheckReturnValue
     @NotNull C password(@NotNull byte[] password);
 
     /**
@@ -63,5 +67,6 @@ public interface Mqtt5SimpleAuthBuilderBase<C extends Mqtt5SimpleAuthBuilderBase
      * @param password the password as {@link ByteBuffer}.
      * @return the builder that is now complete as the password is set.
      */
+    @CheckReturnValue
     @NotNull C password(@NotNull ByteBuffer password);
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.connect;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,6 +35,7 @@ public interface Mqtt5ConnectBuilder extends Mqtt5ConnectBuilderBase<Mqtt5Connec
      *
      * @return the built {@link Mqtt5Connect}.
      */
+    @CheckReturnValue
     @NotNull Mqtt5Connect build();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.connect;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.mqtt5.auth.Mqtt5EnhancedAuthMechanism;
 import com.hivemq.client.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
@@ -46,6 +47,7 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      * @param keepAlive the keep alive in seconds.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B keepAlive(int keepAlive);
 
     /**
@@ -53,6 +55,7 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      *
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B noKeepAlive();
 
     /**
@@ -61,6 +64,7 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      * @param cleanStart whether the client starts a clean session.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B cleanStart(boolean cleanStart);
 
     /**
@@ -71,6 +75,7 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      * @param sessionExpiryInterval the session expiry interval in seconds.
      * @return teh builder.
      */
+    @CheckReturnValue
     @NotNull B sessionExpiryInterval(long sessionExpiryInterval);
 
     /**
@@ -79,6 +84,7 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      *
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B noSessionExpiry();
 
     /**
@@ -87,6 +93,7 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      * @param restrictions the restrictions from the client.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B restrictions(@NotNull Mqtt5ConnectRestrictions restrictions);
 
     /**
@@ -98,6 +105,7 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      * @return the fluent builder for the restrictions.
      * @see #restrictions(Mqtt5ConnectRestrictions)
      */
+    @CheckReturnValue
     @NotNull Mqtt5ConnectRestrictionsBuilder.Nested<? extends B> restrictions();
 
     /**
@@ -107,6 +115,7 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      *                   related data.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B simpleAuth(@Nullable Mqtt5SimpleAuth simpleAuth);
 
     /**
@@ -119,6 +128,7 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      * @return the fluent builder for the simple auth related data.
      * @see #simpleAuth(Mqtt5SimpleAuth)
      */
+    @CheckReturnValue
     @NotNull Mqtt5SimpleAuthBuilder.Nested<? extends B> simpleAuth();
 
     /**
@@ -128,6 +138,7 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      *                              enhanced auth mechanism.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B enhancedAuth(@Nullable Mqtt5EnhancedAuthMechanism enhancedAuthMechanism);
 
     /**
@@ -136,6 +147,7 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      * @param willPublish the Will Publish or <code>null</code> to remove any previously set Will Publish.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B willPublish(@Nullable Mqtt5Publish willPublish);
 
     /**
@@ -148,6 +160,7 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      * @return the fluent builder for the Will Publish.
      * @see #willPublish(Mqtt5Publish)
      */
+    @CheckReturnValue
     @NotNull Mqtt5WillPublishBuilder.Nested<? extends B> willPublish();
 
     /**
@@ -156,6 +169,7 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      * @param userProperties the User Properties.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B userProperties(@NotNull Mqtt5UserProperties userProperties);
 
     /**
@@ -167,5 +181,6 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      * @return the fluent builder for the User Properties.
      * @see #userProperties(Mqtt5UserProperties)
      */
+    @CheckReturnValue
     @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends B> userProperties();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictionsBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictionsBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.connect;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -35,6 +36,7 @@ public interface Mqtt5ConnectRestrictionsBuilder
      *
      * @return the built {@link Mqtt5ConnectRestrictions}.
      */
+    @CheckReturnValue
     @NotNull Mqtt5ConnectRestrictions build();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictionsBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictionsBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.connect;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -38,6 +39,7 @@ public interface Mqtt5ConnectRestrictionsBuilderBase<B extends Mqtt5ConnectRestr
      * @param receiveMaximum the receive maximum.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B receiveMaximum(int receiveMaximum);
 
     /**
@@ -50,6 +52,7 @@ public interface Mqtt5ConnectRestrictionsBuilderBase<B extends Mqtt5ConnectRestr
      * @param receiveMaximum the send maximum.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B sendMaximum(int receiveMaximum);
 
     /**
@@ -60,6 +63,7 @@ public interface Mqtt5ConnectRestrictionsBuilderBase<B extends Mqtt5ConnectRestr
      * @param maximumPacketSize the maximum packet size.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B maximumPacketSize(int maximumPacketSize);
 
     /**
@@ -72,6 +76,7 @@ public interface Mqtt5ConnectRestrictionsBuilderBase<B extends Mqtt5ConnectRestr
      * @param maximumPacketSize the maximum packet size for sending.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B sendMaximumPacketSize(int maximumPacketSize);
 
     /**
@@ -82,6 +87,7 @@ public interface Mqtt5ConnectRestrictionsBuilderBase<B extends Mqtt5ConnectRestr
      * @param topicAliasMaximum the topic alias maximum.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B topicAliasMaximum(int topicAliasMaximum);
 
     /**
@@ -94,6 +100,7 @@ public interface Mqtt5ConnectRestrictionsBuilderBase<B extends Mqtt5ConnectRestr
      * @param topicAliasMaximum the topic alias maximum for sending.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B sendTopicAliasMaximum(int topicAliasMaximum);
 
     /**
@@ -102,6 +109,7 @@ public interface Mqtt5ConnectRestrictionsBuilderBase<B extends Mqtt5ConnectRestr
      * @param requestProblemInformation whether problem information is requested.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B requestProblemInformation(boolean requestProblemInformation);
 
     /**
@@ -110,5 +118,6 @@ public interface Mqtt5ConnectRestrictionsBuilderBase<B extends Mqtt5ConnectRestr
      * @param requestResponseInformation whether response information is requested.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B requestResponseInformation(boolean requestResponseInformation);
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.disconnect;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,6 +35,7 @@ public interface Mqtt5DisconnectBuilder extends Mqtt5DisconnectBuilderBase<Mqtt5
      *
      * @return the built {@link Mqtt5Disconnect}.
      */
+    @CheckReturnValue
     @NotNull Mqtt5Disconnect build();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.disconnect;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.datatypes.MqttUtf8String;
 import com.hivemq.client.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
@@ -40,6 +41,7 @@ public interface Mqtt5DisconnectBuilderBase<B extends Mqtt5DisconnectBuilderBase
      * @param reasonCode the Reason Code.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B reasonCode(@NotNull Mqtt5DisconnectReasonCode reasonCode);
 
     /**
@@ -50,6 +52,7 @@ public interface Mqtt5DisconnectBuilderBase<B extends Mqtt5DisconnectBuilderBase
      * @param sessionExpiryInterval the session expiry interval in seconds.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B sessionExpiryInterval(long sessionExpiryInterval);
 
     /**
@@ -58,6 +61,7 @@ public interface Mqtt5DisconnectBuilderBase<B extends Mqtt5DisconnectBuilderBase
      *
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B noSessionExpiry();
 
     /**
@@ -66,6 +70,7 @@ public interface Mqtt5DisconnectBuilderBase<B extends Mqtt5DisconnectBuilderBase
      * @param serverReference the server reference.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B serverReference(@Nullable String serverReference);
 
     /**
@@ -74,6 +79,7 @@ public interface Mqtt5DisconnectBuilderBase<B extends Mqtt5DisconnectBuilderBase
      * @param serverReference the server reference.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B serverReference(@Nullable MqttUtf8String serverReference);
 
     /**
@@ -82,6 +88,7 @@ public interface Mqtt5DisconnectBuilderBase<B extends Mqtt5DisconnectBuilderBase
      * @param reasonString the Reason String.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B reasonString(@Nullable String reasonString);
 
     /**
@@ -90,6 +97,7 @@ public interface Mqtt5DisconnectBuilderBase<B extends Mqtt5DisconnectBuilderBase
      * @param reasonString the Reason String.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B reasonString(@Nullable MqttUtf8String reasonString);
 
     /**
@@ -98,6 +106,7 @@ public interface Mqtt5DisconnectBuilderBase<B extends Mqtt5DisconnectBuilderBase
      * @param userProperties the User Properties.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B userProperties(@NotNull Mqtt5UserProperties userProperties);
 
     /**
@@ -109,5 +118,6 @@ public interface Mqtt5DisconnectBuilderBase<B extends Mqtt5DisconnectBuilderBase
      * @return the fluent builder for the User Properties.
      * @see #userProperties(Mqtt5UserProperties)
      */
+    @CheckReturnValue
     @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends B> userProperties();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.publish;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,6 +35,7 @@ public interface Mqtt5PublishBuilder extends Mqtt5PublishBuilderBase<Mqtt5Publis
      *
      * @return the created builder for a Will Publish.
      */
+    @CheckReturnValue
     @NotNull Mqtt5WillPublishBuilder asWill();
 
     /**
@@ -48,6 +50,7 @@ public interface Mqtt5PublishBuilder extends Mqtt5PublishBuilderBase<Mqtt5Publis
          * @return the created complete builder for a Will Publish.
          */
         @Override
+        @CheckReturnValue
         @NotNull Mqtt5WillPublishBuilder.Complete asWill();
 
         /**
@@ -55,6 +58,7 @@ public interface Mqtt5PublishBuilder extends Mqtt5PublishBuilderBase<Mqtt5Publis
          *
          * @return the built {@link Mqtt5Publish}.
          */
+        @CheckReturnValue
         @NotNull Mqtt5Publish build();
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5PublishBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5PublishBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.publish;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.datatypes.MqttTopic;
@@ -45,6 +46,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
      * @param topic the string representation of the Topic.
      * @return the builder that is now complete as the mandatory Topic is set.
      */
+    @CheckReturnValue
     @NotNull C topic(@NotNull String topic);
 
     /**
@@ -53,6 +55,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
      * @param topic the Topic.
      * @return the builder that is now complete as the mandatory Topic is set.
      */
+    @CheckReturnValue
     @NotNull C topic(@NotNull MqttTopic topic);
 
     /**
@@ -64,6 +67,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
      * @return the fluent builder for the Topic.
      * @see #topic(MqttTopic)
      */
+    @CheckReturnValue
     @NotNull MqttTopicBuilder.Nested<? extends C> topic();
 
     /**
@@ -80,6 +84,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          * @param payload the payload as byte array or <code>null</code> to remove any previously set payload.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C payload(@Nullable byte[] payload);
 
         /**
@@ -88,6 +93,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          * @param payload the payload as {@link ByteBuffer} or <code>null</code> to remove any previously set payload.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C payload(@Nullable ByteBuffer payload);
 
         /**
@@ -96,6 +102,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          * @param qos the QoS.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C qos(@NotNull MqttQos qos);
 
         /**
@@ -104,6 +111,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          * @param retain whether the Publish message should be retained.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C retain(boolean retain);
 
         /**
@@ -114,6 +122,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          * @param messageExpiryInterval the message expiry interval in seconds.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C messageExpiryInterval(long messageExpiryInterval);
 
         /**
@@ -121,6 +130,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          *
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C noMessageExpiry();
 
         /**
@@ -130,6 +140,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          *                               payload format indicator.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C payloadFormatIndicator(@Nullable Mqtt5PayloadFormatIndicator payloadFormatIndicator);
 
         /**
@@ -138,6 +149,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          * @param contentType the content type or <code>null</code> to remove any previously set content type.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C contentType(@Nullable String contentType);
 
         /**
@@ -146,6 +158,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          * @param contentType the content type or <code>null</code> to remove any previously set content type.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C contentType(@Nullable MqttUtf8String contentType);
 
         /**
@@ -154,6 +167,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          * @param responseTopic the response topic or <code>null</code> to remove any previously set response topic.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C responseTopic(@Nullable String responseTopic);
 
         /**
@@ -162,6 +176,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          * @param responseTopic the response topic or <code>null</code> to remove any previously set response topic.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C responseTopic(@Nullable MqttTopic responseTopic);
 
         /**
@@ -173,6 +188,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          * @return the fluent builder for the response topic.
          * @see #responseTopic(MqttTopic)
          */
+        @CheckReturnValue
         @NotNull MqttTopicBuilder.Nested<? extends C> responseTopic();
 
         /**
@@ -182,6 +198,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          *                        correlation data.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C correlationData(@Nullable byte[] correlationData);
 
         /**
@@ -191,6 +208,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          *                        previously set correlation data.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C correlationData(@Nullable ByteBuffer correlationData);
 
         /**
@@ -199,6 +217,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          * @param userProperties the User Properties.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C userProperties(@NotNull Mqtt5UserProperties userProperties);
 
         /**
@@ -210,6 +229,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          * @return the fluent builder for the User Properties.
          * @see #userProperties(Mqtt5UserProperties)
          */
+        @CheckReturnValue
         @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends C> userProperties();
     }
 
@@ -237,6 +257,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
              * @param delayInterval the delay interval in seconds.
              * @return the builder.
              */
+            @CheckReturnValue
             @NotNull C delayInterval(long delayInterval);
         }
     }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.publish;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -41,6 +42,7 @@ public interface Mqtt5WillPublishBuilder extends Mqtt5PublishBuilderBase.WillBas
          *
          * @return the built {@link Mqtt5WillPublish}.
          */
+        @CheckReturnValue
         @NotNull Mqtt5WillPublish build();
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/puback/Mqtt5PubAckBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/puback/Mqtt5PubAckBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.publish.puback;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.datatypes.MqttUtf8String;
 import com.hivemq.client.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
@@ -74,5 +75,6 @@ public interface Mqtt5PubAckBuilder {
      * @return the fluent builder for the User Properties.
      * @see #userProperties(Mqtt5UserProperties)
      */
+    @CheckReturnValue
     @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends Mqtt5PubAckBuilder> userProperties();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/pubcomp/Mqtt5PubCompBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/pubcomp/Mqtt5PubCompBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.publish.pubcomp;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.datatypes.MqttUtf8String;
 import com.hivemq.client.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
@@ -66,6 +67,7 @@ public interface Mqtt5PubCompBuilder {
      * @return the fluent builder for the User Properties.
      * @see #userProperties(Mqtt5UserProperties)
      */
+    @CheckReturnValue
     @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends Mqtt5PubCompBuilder> userProperties();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/pubrec/Mqtt5PubRecBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/pubrec/Mqtt5PubRecBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.publish.pubrec;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.datatypes.MqttUtf8String;
 import com.hivemq.client.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
@@ -74,5 +75,6 @@ public interface Mqtt5PubRecBuilder {
      * @return the fluent builder for the User Properties.
      * @see #userProperties(Mqtt5UserProperties)
      */
+    @CheckReturnValue
     @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends Mqtt5PubRecBuilder> userProperties();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/pubrel/Mqtt5PubRelBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/pubrel/Mqtt5PubRelBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.publish.pubrel;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.datatypes.MqttUtf8String;
 import com.hivemq.client.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
@@ -66,6 +67,7 @@ public interface Mqtt5PubRelBuilder {
      * @return the fluent builder for the User Properties.
      * @see #userProperties(Mqtt5UserProperties)
      */
+    @CheckReturnValue
     @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends Mqtt5PubRelBuilder> userProperties();
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.subscribe;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -41,6 +42,7 @@ public interface Mqtt5SubscribeBuilder extends Mqtt5SubscribeBuilderBase<Mqtt5Su
          *
          * @return the built {@link Mqtt5Subscribe}.
          */
+        @CheckReturnValue
         @NotNull Mqtt5Subscribe build();
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.subscribe;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import com.hivemq.client.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
@@ -42,6 +43,7 @@ public interface Mqtt5SubscribeBuilderBase<C extends Mqtt5SubscribeBuilderBase.C
      * @param subscription the subscription.
      * @return the builder that is now complete as at least one subscription is set.
      */
+    @CheckReturnValue
     @NotNull C addSubscription(@NotNull Mqtt5Subscription subscription);
 
     /**
@@ -54,6 +56,7 @@ public interface Mqtt5SubscribeBuilderBase<C extends Mqtt5SubscribeBuilderBase.C
      * @return the fluent builder for the subscription.
      * @see #addSubscription(Mqtt5Subscription)
      */
+    @CheckReturnValue
     @NotNull Mqtt5SubscriptionBuilder.Nested<? extends C> addSubscription();
 
     /**
@@ -100,6 +103,7 @@ public interface Mqtt5SubscribeBuilderBase<C extends Mqtt5SubscribeBuilderBase.C
          * @param userProperties the User Properties.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C userProperties(@NotNull Mqtt5UserProperties userProperties);
 
         /**
@@ -111,6 +115,7 @@ public interface Mqtt5SubscribeBuilderBase<C extends Mqtt5SubscribeBuilderBase.C
          * @return the fluent builder for the User Properties.
          * @see #userProperties(Mqtt5UserProperties)
          */
+        @CheckReturnValue
         @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends C> userProperties();
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.subscribe;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -41,6 +42,7 @@ public interface Mqtt5SubscriptionBuilder extends Mqtt5SubscriptionBuilderBase<M
          *
          * @return the built {@link Mqtt5Subscription}.
          */
+        @CheckReturnValue
         @NotNull Mqtt5Subscription build();
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.subscribe;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.datatypes.MqttTopicFilter;
@@ -39,6 +40,7 @@ public interface Mqtt5SubscriptionBuilderBase<C extends Mqtt5SubscriptionBuilder
      * @param topicFilter the string representation of the Topic Filter.
      * @return the builder that is now complete as the mandatory Topic Filter is set.
      */
+    @CheckReturnValue
     @NotNull C topicFilter(@NotNull String topicFilter);
 
     /**
@@ -47,6 +49,7 @@ public interface Mqtt5SubscriptionBuilderBase<C extends Mqtt5SubscriptionBuilder
      * @param topicFilter the Topic Filter.
      * @return the builder that is now complete as the mandatory Topic Filter is set.
      */
+    @CheckReturnValue
     @NotNull C topicFilter(@NotNull MqttTopicFilter topicFilter);
 
     /**
@@ -59,6 +62,7 @@ public interface Mqtt5SubscriptionBuilderBase<C extends Mqtt5SubscriptionBuilder
      * @return the fluent builder for the Topic Filter.
      * @see #topicFilter(MqttTopicFilter)
      */
+    @CheckReturnValue
     @NotNull MqttTopicFilterBuilder.Nested<? extends C> topicFilter();
 
     /**
@@ -75,6 +79,7 @@ public interface Mqtt5SubscriptionBuilderBase<C extends Mqtt5SubscriptionBuilder
          * @param qos the QoS.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C qos(@NotNull MqttQos qos);
 
         /**
@@ -83,6 +88,7 @@ public interface Mqtt5SubscriptionBuilderBase<C extends Mqtt5SubscriptionBuilder
          * @param noLocal whether the subscription is not local.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C noLocal(boolean noLocal);
 
         /**
@@ -91,6 +97,7 @@ public interface Mqtt5SubscriptionBuilderBase<C extends Mqtt5SubscriptionBuilder
          * @param retainHandling the retain handling.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C retainHandling(@NotNull Mqtt5RetainHandling retainHandling);
 
         /**
@@ -101,6 +108,7 @@ public interface Mqtt5SubscriptionBuilderBase<C extends Mqtt5SubscriptionBuilder
          *                          flag.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C retainAsPublished(boolean retainAsPublished);
     }
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilder.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.unsubscribe;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
@@ -44,6 +45,7 @@ public interface Mqtt5UnsubscribeBuilder extends Mqtt5UnsubscribeBuilderBase<Mqt
          *
          * @return the built {@link Mqtt5Unsubscribe}.
          */
+        @CheckReturnValue
         @NotNull Mqtt5Unsubscribe build();
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilderBase.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.mqtt.mqtt5.message.unsubscribe;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.annotations.DoNotImplement;
 import com.hivemq.client.mqtt.datatypes.MqttTopicFilter;
 import com.hivemq.client.mqtt.datatypes.MqttTopicFilterBuilder;
@@ -45,6 +46,7 @@ public interface Mqtt5UnsubscribeBuilderBase<C extends Mqtt5UnsubscribeBuilderBa
      * @param topicFilter the string representation of the Topic Filter.
      * @return the builder that is now complete as at least one Topic Filter is set.
      */
+    @CheckReturnValue
     @NotNull C addTopicFilter(@NotNull String topicFilter);
 
     /**
@@ -54,6 +56,7 @@ public interface Mqtt5UnsubscribeBuilderBase<C extends Mqtt5UnsubscribeBuilderBa
      * @param topicFilter the Topic Filter.
      * @return the builder that is now complete as at least one Topic Filter is set.
      */
+    @CheckReturnValue
     @NotNull C addTopicFilter(@NotNull MqttTopicFilter topicFilter);
 
     /**
@@ -66,6 +69,7 @@ public interface Mqtt5UnsubscribeBuilderBase<C extends Mqtt5UnsubscribeBuilderBa
      * @return the fluent builder for the Topic Filter.
      * @see #addTopicFilter(MqttTopicFilter)
      */
+    @CheckReturnValue
     @NotNull MqttTopicFilterBuilder.Nested<? extends C> addTopicFilter();
 
     /**
@@ -104,6 +108,7 @@ public interface Mqtt5UnsubscribeBuilderBase<C extends Mqtt5UnsubscribeBuilderBa
      * @param subscribe the Subscribe message.
      * @return the builder that is now complete as at least one Topic Filter is set.
      */
+    @CheckReturnValue
     @NotNull C reverse(@NotNull Mqtt5Subscribe subscribe);
 
     /**
@@ -120,6 +125,7 @@ public interface Mqtt5UnsubscribeBuilderBase<C extends Mqtt5UnsubscribeBuilderBa
          * @param userProperties the User Properties.
          * @return the builder.
          */
+        @CheckReturnValue
         @NotNull C userProperties(@NotNull Mqtt5UserProperties userProperties);
 
         /**
@@ -131,6 +137,7 @@ public interface Mqtt5UnsubscribeBuilderBase<C extends Mqtt5UnsubscribeBuilderBa
          * @return the fluent builder for the User Properties.
          * @see #userProperties(Mqtt5UserProperties)
          */
+        @CheckReturnValue
         @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends C> userProperties();
     }
 
@@ -148,6 +155,7 @@ public interface Mqtt5UnsubscribeBuilderBase<C extends Mqtt5UnsubscribeBuilderBa
          * @param topicFilter the string representation of the Topic Filter.
          * @return the builder that is now complete as the mandatory Topic Filter is set.
          */
+        @CheckReturnValue
         @NotNull C topicFilter(@NotNull String topicFilter);
 
         /**
@@ -156,6 +164,7 @@ public interface Mqtt5UnsubscribeBuilderBase<C extends Mqtt5UnsubscribeBuilderBa
          * @param topicFilter the Topic Filter.
          * @return the builder that is now complete as the mandatory Topic Filter is set.
          */
+        @CheckReturnValue
         @NotNull C topicFilter(@NotNull MqttTopicFilter topicFilter);
 
         /**
@@ -168,6 +177,7 @@ public interface Mqtt5UnsubscribeBuilderBase<C extends Mqtt5UnsubscribeBuilderBa
          * @return the fluent builder for the Topic Filter.
          * @see #addTopicFilter(MqttTopicFilter)
          */
+        @CheckReturnValue
         @NotNull MqttTopicFilterBuilder.Nested<? extends C> topicFilter();
     }
 }

--- a/src/main/java/com/hivemq/client/rx/FlowableWithSingle.java
+++ b/src/main/java/com/hivemq/client/rx/FlowableWithSingle.java
@@ -17,6 +17,7 @@
 
 package com.hivemq.client.rx;
 
+import com.hivemq.client.annotations.CheckReturnValue;
 import com.hivemq.client.internal.rx.WithSingleStrictSubscriber;
 import com.hivemq.client.internal.rx.operators.FlowableWithSingleMap;
 import com.hivemq.client.internal.rx.operators.FlowableWithSingleMapError;
@@ -58,6 +59,7 @@ public abstract class FlowableWithSingle<F, S> extends Flowable<F> implements Pu
      * @return a {@link FlowableWithSingle} notified from the upstream on the specified Scheduler.
      * @see Flowable#observeOn(Scheduler)
      */
+    @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final @NotNull FlowableWithSingle<F, S> observeOnBoth(final @NotNull Scheduler scheduler) {
@@ -73,6 +75,7 @@ public abstract class FlowableWithSingle<F, S> extends Flowable<F> implements Pu
      * @return a {@link FlowableWithSingle} notified from the upstream on the specified Scheduler.
      * @see Flowable#observeOn(Scheduler)
      */
+    @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final @NotNull FlowableWithSingle<F, S> observeOnBoth(
@@ -91,6 +94,7 @@ public abstract class FlowableWithSingle<F, S> extends Flowable<F> implements Pu
      * @return a {@link FlowableWithSingle} notified from the upstream on the specified Scheduler.
      * @see Flowable#observeOn(Scheduler)
      */
+    @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final @NotNull FlowableWithSingle<F, S> observeOnBoth(
@@ -108,6 +112,7 @@ public abstract class FlowableWithSingle<F, S> extends Flowable<F> implements Pu
      * @param <SM>         the type of the mapped single item.
      * @return a {@link FlowableWithSingle} that applies the mapper function to the single item.
      */
+    @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <SM> @NotNull FlowableWithSingle<F, SM> mapSingle(
@@ -128,6 +133,7 @@ public abstract class FlowableWithSingle<F, S> extends Flowable<F> implements Pu
      * @param <FM>           the type of the mapped flow items.
      * @return a {@link FlowableWithSingle} that applies the mapper functions to the single item and the flow of items.
      */
+    @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <FM, SM> @NotNull FlowableWithSingle<FM, SM> mapBoth(
@@ -145,6 +151,7 @@ public abstract class FlowableWithSingle<F, S> extends Flowable<F> implements Pu
      * @param mapper the mapper function to apply to an error.
      * @return a {@link FlowableWithSingle} that applies the mapper function to an error.
      */
+    @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final @NotNull FlowableWithSingle<F, S> mapError(
@@ -160,6 +167,7 @@ public abstract class FlowableWithSingle<F, S> extends Flowable<F> implements Pu
      * @param singleConsumer the consumer of the single item.
      * @return a {@link FlowableWithSingle} that calls the consumer with the single item.
      */
+    @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final @NotNull FlowableWithSingle<F, S> doOnSingle(final @NotNull Consumer<? super S> singleConsumer) {
@@ -206,6 +214,7 @@ public abstract class FlowableWithSingle<F, S> extends Flowable<F> implements Pu
      *
      * @return a future for the single item of type S.
      */
+    @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final @NotNull CompletableFuture<S> subscribeSingleFuture() {
@@ -230,6 +239,7 @@ public abstract class FlowableWithSingle<F, S> extends Flowable<F> implements Pu
      * @param onNext see {@link #subscribe(Consumer)}
      * @return a future for the single item of type S.
      */
+    @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final @NotNull CompletableFuture<S> subscribeSingleFuture(final @NotNull Consumer<? super F> onNext) {
@@ -256,6 +266,7 @@ public abstract class FlowableWithSingle<F, S> extends Flowable<F> implements Pu
      * @param onError see {@link #subscribe(Consumer, Consumer)}
      * @return a future for the single item of type S.
      */
+    @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final @NotNull CompletableFuture<S> subscribeSingleFuture(
@@ -285,6 +296,7 @@ public abstract class FlowableWithSingle<F, S> extends Flowable<F> implements Pu
      * @param onComplete see {@link #subscribe(Consumer, Consumer, Action)}
      * @return a future for the single item of type S.
      */
+    @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final @NotNull CompletableFuture<S> subscribeSingleFuture(
@@ -313,6 +325,7 @@ public abstract class FlowableWithSingle<F, S> extends Flowable<F> implements Pu
      * @param subscriber see {@link #subscribe(Subscriber)}
      * @return a future for the single item of type S.
      */
+    @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final @NotNull CompletableFuture<S> subscribeSingleFuture(final @NotNull Subscriber<? super F> subscriber) {


### PR DESCRIPTION
**Motivation**
Add IDE support for checking return values of builders.
Missing a `send()` call will now result in a warning by the IDE (tested with IntelliJ)

**Changes**
Added CheckReturnValue annotation to all builder methods
