### PR TITLE
Improvement/add all methods generics

### DIFF
--- a/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttUserPropertiesImplBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttUserPropertiesImplBuilder.java
@@ -73,14 +73,14 @@ public abstract class MqttUserPropertiesImplBuilder<B extends MqttUserProperties
         return self();
     }
 
-    public @NotNull B addAll(final @Nullable Collection<@Nullable Mqtt5UserProperty> userProperties) {
+    public @NotNull B addAll(final @Nullable Collection<@Nullable ? extends Mqtt5UserProperty> userProperties) {
         Checks.notNull(userProperties, "User Properties");
         listBuilder.ensureFree(userProperties.size());
         userProperties.forEach(this::add);
         return self();
     }
 
-    public @NotNull B addAll(final @Nullable Stream<@Nullable Mqtt5UserProperty> userProperties) {
+    public @NotNull B addAll(final @Nullable Stream<@Nullable ? extends Mqtt5UserProperty> userProperties) {
         Checks.notNull(userProperties, "User Properties");
         userProperties.forEach(this::add);
         return self();

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/MqttSubscribeBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/MqttSubscribeBuilder.java
@@ -78,7 +78,9 @@ public abstract class MqttSubscribeBuilder<B extends MqttSubscribeBuilder<B>> {
         return self();
     }
 
-    public @NotNull B addSubscriptions(final @Nullable Collection<@Nullable Mqtt5Subscription> subscriptions) {
+    public @NotNull B addSubscriptions(
+            final @Nullable Collection<@Nullable ? extends Mqtt5Subscription> subscriptions) {
+
         Checks.notNull(subscriptions, "Subscriptions");
         buildFirstSubscription();
         subscriptionsBuilder.ensureFree(subscriptions.size());
@@ -87,7 +89,7 @@ public abstract class MqttSubscribeBuilder<B extends MqttSubscribeBuilder<B>> {
         return self();
     }
 
-    public @NotNull B addSubscriptions(final @Nullable Stream<@Nullable Mqtt5Subscription> subscriptions) {
+    public @NotNull B addSubscriptions(final @Nullable Stream<@Nullable ? extends Mqtt5Subscription> subscriptions) {
         Checks.notNull(subscriptions, "Subscriptions");
         buildFirstSubscription();
         subscriptions.forEach(this::addSubscription);

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeViewBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeViewBuilder.java
@@ -74,7 +74,9 @@ public abstract class Mqtt3SubscribeViewBuilder<B extends Mqtt3SubscribeViewBuil
         return self();
     }
 
-    public @NotNull B addSubscriptions(final @Nullable Collection<@Nullable Mqtt3Subscription> subscriptions) {
+    public @NotNull B addSubscriptions(
+            final @Nullable Collection<@Nullable ? extends Mqtt3Subscription> subscriptions) {
+
         Checks.notNull(subscriptions, "Subscriptions");
         buildFirstSubscription();
         subscriptionsBuilder.ensureFree(subscriptions.size());
@@ -83,7 +85,7 @@ public abstract class Mqtt3SubscribeViewBuilder<B extends Mqtt3SubscribeViewBuil
         return self();
     }
 
-    public @NotNull B addSubscriptions(final @Nullable Stream<@Nullable Mqtt3Subscription> subscriptions) {
+    public @NotNull B addSubscriptions(final @Nullable Stream<@Nullable ? extends Mqtt3Subscription> subscriptions) {
         Checks.notNull(subscriptions, "Subscriptions");
         buildFirstSubscription();
         subscriptions.forEach(this::addSubscription);

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/unsubscribe/MqttUnsubscribeBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/unsubscribe/MqttUnsubscribeBuilder.java
@@ -80,7 +80,7 @@ public abstract class MqttUnsubscribeBuilder<B extends MqttUnsubscribeBuilder<B>
         return self();
     }
 
-    public @NotNull B addTopicFilters(final @Nullable Collection<@Nullable MqttTopicFilter> topicFilters) {
+    public @NotNull B addTopicFilters(final @Nullable Collection<@Nullable ? extends MqttTopicFilter> topicFilters) {
         Checks.notNull(topicFilters, "Topic Filters");
         topicFiltersBuilder.ensureFree(topicFilters.size());
         topicFilters.forEach(this::addTopicFilter);
@@ -88,7 +88,7 @@ public abstract class MqttUnsubscribeBuilder<B extends MqttUnsubscribeBuilder<B>
         return self();
     }
 
-    public @NotNull B addTopicFilters(final @Nullable Stream<@Nullable MqttTopicFilter> topicFilters) {
+    public @NotNull B addTopicFilters(final @Nullable Stream<@Nullable ? extends MqttTopicFilter> topicFilters) {
         Checks.notNull(topicFilters, "Topic Filters");
         topicFilters.forEach(this::addTopicFilter);
         ensureAtLeastOneSubscription();

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeViewBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeViewBuilder.java
@@ -77,7 +77,7 @@ public abstract class Mqtt3UnsubscribeViewBuilder<B extends Mqtt3UnsubscribeView
         return self();
     }
 
-    public @NotNull B addTopicFilters(final @Nullable Collection<@Nullable MqttTopicFilter> topicFilters) {
+    public @NotNull B addTopicFilters(final @Nullable Collection<@Nullable ? extends MqttTopicFilter> topicFilters) {
         Checks.notNull(topicFilters, "Topic Filters");
         topicFiltersBuilder.ensureFree(topicFilters.size());
         topicFilters.forEach(this::addTopicFilter);
@@ -85,7 +85,7 @@ public abstract class Mqtt3UnsubscribeViewBuilder<B extends Mqtt3UnsubscribeView
         return self();
     }
 
-    public @NotNull B addTopicFilters(final @Nullable Stream<@Nullable MqttTopicFilter> topicFilters) {
+    public @NotNull B addTopicFilters(final @Nullable Stream<@Nullable ? extends MqttTopicFilter> topicFilters) {
         Checks.notNull(topicFilters, "Topic Filters");
         topicFilters.forEach(this::addTopicFilter);
         ensureAtLeastOneSubscription();

--- a/src/main/java/com/hivemq/client/mqtt/MqttWebSocketConfigBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttWebSocketConfigBuilderBase.java
@@ -46,6 +46,7 @@ public interface MqttWebSocketConfigBuilderBase<B extends MqttWebSocketConfigBui
      * @param queryString the query string.
      * @return the builder.
      */
+    @CheckReturnValue
     @NotNull B queryString(@NotNull String queryString);
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeBuilderBase.java
@@ -75,7 +75,7 @@ public interface Mqtt3SubscribeBuilderBase<C extends Mqtt3SubscribeBuilderBase<C
      * @return the builder that is now complete as at least one subscription is set.
      * @since 1.2
      */
-    @NotNull C addSubscriptions(@NotNull Collection<@NotNull Mqtt3Subscription> subscriptions);
+    @NotNull C addSubscriptions(@NotNull Collection<@NotNull ? extends Mqtt3Subscription> subscriptions);
 
     /**
      * Adds a stream of {@link Mqtt3Subscription}s to the {@link Mqtt3Subscribe#getSubscriptions() list of
@@ -85,7 +85,7 @@ public interface Mqtt3SubscribeBuilderBase<C extends Mqtt3SubscribeBuilderBase<C
      * @return the builder that is now complete as at least one subscription is set.
      * @since 1.2
      */
-    @NotNull C addSubscriptions(@NotNull Stream<@NotNull Mqtt3Subscription> subscriptions);
+    @NotNull C addSubscriptions(@NotNull Stream<@NotNull ? extends Mqtt3Subscription> subscriptions);
 
     /**
      * {@link Mqtt3SubscribeBuilderBase} that provides additional methods for the first subscription.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeBuilderBase.java
@@ -65,6 +65,7 @@ public interface Mqtt3SubscribeBuilderBase<C extends Mqtt3SubscribeBuilderBase<C
      * @return the builder that is now complete as at least one subscription is set.
      * @since 1.2
      */
+    @CheckReturnValue
     @NotNull C addSubscriptions(@NotNull Mqtt3Subscription @NotNull ... subscriptions);
 
     /**
@@ -75,6 +76,7 @@ public interface Mqtt3SubscribeBuilderBase<C extends Mqtt3SubscribeBuilderBase<C
      * @return the builder that is now complete as at least one subscription is set.
      * @since 1.2
      */
+    @CheckReturnValue
     @NotNull C addSubscriptions(@NotNull Collection<@NotNull ? extends Mqtt3Subscription> subscriptions);
 
     /**
@@ -85,6 +87,7 @@ public interface Mqtt3SubscribeBuilderBase<C extends Mqtt3SubscribeBuilderBase<C
      * @return the builder that is now complete as at least one subscription is set.
      * @since 1.2
      */
+    @CheckReturnValue
     @NotNull C addSubscriptions(@NotNull Stream<@NotNull ? extends Mqtt3Subscription> subscriptions);
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilderBase.java
@@ -78,6 +78,7 @@ public interface Mqtt3UnsubscribeBuilderBase<C extends Mqtt3UnsubscribeBuilderBa
      * @return the builder that is now complete as at least one Topic Filter is set.
      * @since 1.2
      */
+    @CheckReturnValue
     @NotNull C addTopicFilters(@NotNull MqttTopicFilter @NotNull ... topicFilters);
 
     /**
@@ -88,6 +89,7 @@ public interface Mqtt3UnsubscribeBuilderBase<C extends Mqtt3UnsubscribeBuilderBa
      * @return the builder that is now complete as at least one Topic Filter is set.
      * @since 1.2
      */
+    @CheckReturnValue
     @NotNull C addTopicFilters(@NotNull Collection<@NotNull ? extends MqttTopicFilter> topicFilters);
 
     /**
@@ -98,6 +100,7 @@ public interface Mqtt3UnsubscribeBuilderBase<C extends Mqtt3UnsubscribeBuilderBa
      * @return the builder that is now complete as at least one Topic Filter is set.
      * @since 1.2
      */
+    @CheckReturnValue
     @NotNull C addTopicFilters(@NotNull Stream<@NotNull ? extends MqttTopicFilter> topicFilters);
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilderBase.java
@@ -88,7 +88,7 @@ public interface Mqtt3UnsubscribeBuilderBase<C extends Mqtt3UnsubscribeBuilderBa
      * @return the builder that is now complete as at least one Topic Filter is set.
      * @since 1.2
      */
-    @NotNull C addTopicFilters(@NotNull Collection<@NotNull MqttTopicFilter> topicFilters);
+    @NotNull C addTopicFilters(@NotNull Collection<@NotNull ? extends MqttTopicFilter> topicFilters);
 
     /**
      * Adds a stream of {@link MqttTopicFilter Topic Filters} to the {@link Mqtt3Unsubscribe#getTopicFilters() list of
@@ -98,7 +98,7 @@ public interface Mqtt3UnsubscribeBuilderBase<C extends Mqtt3UnsubscribeBuilderBa
      * @return the builder that is now complete as at least one Topic Filter is set.
      * @since 1.2
      */
-    @NotNull C addTopicFilters(@NotNull Stream<@NotNull MqttTopicFilter> topicFilters);
+    @NotNull C addTopicFilters(@NotNull Stream<@NotNull ? extends MqttTopicFilter> topicFilters);
 
     /**
      * Reverses the subscriptions of a Subscribe message by adding their Topic Filters.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/datatypes/Mqtt5UserPropertiesBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/datatypes/Mqtt5UserPropertiesBuilderBase.java
@@ -71,6 +71,7 @@ public interface Mqtt5UserPropertiesBuilderBase<B extends Mqtt5UserPropertiesBui
      * @return the builder.
      * @since 1.2
      */
+    @CheckReturnValue
     @NotNull B addAll(@NotNull Mqtt5UserProperty @NotNull ... userProperties);
 
     /**
@@ -80,6 +81,7 @@ public interface Mqtt5UserPropertiesBuilderBase<B extends Mqtt5UserPropertiesBui
      * @return the builder.
      * @since 1.2
      */
+    @CheckReturnValue
     @NotNull B addAll(@NotNull Collection<@NotNull ? extends Mqtt5UserProperty> userProperties);
 
     /**
@@ -89,5 +91,6 @@ public interface Mqtt5UserPropertiesBuilderBase<B extends Mqtt5UserPropertiesBui
      * @return the builder.
      * @since 1.2
      */
+    @CheckReturnValue
     @NotNull B addAll(@NotNull Stream<@NotNull ? extends Mqtt5UserProperty> userProperties);
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/datatypes/Mqtt5UserPropertiesBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/datatypes/Mqtt5UserPropertiesBuilderBase.java
@@ -80,7 +80,7 @@ public interface Mqtt5UserPropertiesBuilderBase<B extends Mqtt5UserPropertiesBui
      * @return the builder.
      * @since 1.2
      */
-    @NotNull B addAll(@NotNull Collection<@NotNull Mqtt5UserProperty> userProperties);
+    @NotNull B addAll(@NotNull Collection<@NotNull ? extends Mqtt5UserProperty> userProperties);
 
     /**
      * Adds a stream of {@link Mqtt5UserProperty User Properties}.
@@ -89,5 +89,5 @@ public interface Mqtt5UserPropertiesBuilderBase<B extends Mqtt5UserPropertiesBui
      * @return the builder.
      * @since 1.2
      */
-    @NotNull B addAll(@NotNull Stream<@NotNull Mqtt5UserProperty> userProperties);
+    @NotNull B addAll(@NotNull Stream<@NotNull ? extends Mqtt5UserProperty> userProperties);
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilderBase.java
@@ -77,7 +77,7 @@ public interface Mqtt5SubscribeBuilderBase<C extends Mqtt5SubscribeBuilderBase.C
      * @return the builder that is now complete as at least one subscription is set.
      * @since 1.2
      */
-    @NotNull C addSubscriptions(@NotNull Collection<@NotNull Mqtt5Subscription> subscriptions);
+    @NotNull C addSubscriptions(@NotNull Collection<@NotNull ? extends Mqtt5Subscription> subscriptions);
 
     /**
      * Adds a stream of {@link Mqtt5Subscription}s to the {@link Mqtt5Subscribe#getSubscriptions() list of
@@ -87,7 +87,7 @@ public interface Mqtt5SubscribeBuilderBase<C extends Mqtt5SubscribeBuilderBase.C
      * @return the builder that is now complete as at least one subscription is set.
      * @since 1.2
      */
-    @NotNull C addSubscriptions(@NotNull Stream<@NotNull Mqtt5Subscription> subscriptions);
+    @NotNull C addSubscriptions(@NotNull Stream<@NotNull ? extends Mqtt5Subscription> subscriptions);
 
     /**
      * {@link Mqtt5SubscribeBuilderBase} that is complete which means all mandatory fields are set.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilderBase.java
@@ -67,6 +67,7 @@ public interface Mqtt5SubscribeBuilderBase<C extends Mqtt5SubscribeBuilderBase.C
      * @return the builder that is now complete as at least one subscription is set.
      * @since 1.2
      */
+    @CheckReturnValue
     @NotNull C addSubscriptions(@NotNull Mqtt5Subscription @NotNull ... subscriptions);
 
     /**
@@ -77,6 +78,7 @@ public interface Mqtt5SubscribeBuilderBase<C extends Mqtt5SubscribeBuilderBase.C
      * @return the builder that is now complete as at least one subscription is set.
      * @since 1.2
      */
+    @CheckReturnValue
     @NotNull C addSubscriptions(@NotNull Collection<@NotNull ? extends Mqtt5Subscription> subscriptions);
 
     /**
@@ -87,6 +89,7 @@ public interface Mqtt5SubscribeBuilderBase<C extends Mqtt5SubscribeBuilderBase.C
      * @return the builder that is now complete as at least one subscription is set.
      * @since 1.2
      */
+    @CheckReturnValue
     @NotNull C addSubscriptions(@NotNull Stream<@NotNull ? extends Mqtt5Subscription> subscriptions);
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilderBase.java
@@ -80,6 +80,7 @@ public interface Mqtt5UnsubscribeBuilderBase<C extends Mqtt5UnsubscribeBuilderBa
      * @return the builder that is now complete as at least one Topic Filter is set.
      * @since 1.2
      */
+    @CheckReturnValue
     @NotNull C addTopicFilters(@NotNull MqttTopicFilter @NotNull ... topicFilters);
 
     /**
@@ -90,6 +91,7 @@ public interface Mqtt5UnsubscribeBuilderBase<C extends Mqtt5UnsubscribeBuilderBa
      * @return the builder that is now complete as at least one Topic Filter is set.
      * @since 1.2
      */
+    @CheckReturnValue
     @NotNull C addTopicFilters(@NotNull Collection<@NotNull ? extends MqttTopicFilter> topicFilters);
 
     /**
@@ -100,6 +102,7 @@ public interface Mqtt5UnsubscribeBuilderBase<C extends Mqtt5UnsubscribeBuilderBa
      * @return the builder that is now complete as at least one Topic Filter is set.
      * @since 1.2
      */
+    @CheckReturnValue
     @NotNull C addTopicFilters(@NotNull Stream<@NotNull ? extends MqttTopicFilter> topicFilters);
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilderBase.java
@@ -90,7 +90,7 @@ public interface Mqtt5UnsubscribeBuilderBase<C extends Mqtt5UnsubscribeBuilderBa
      * @return the builder that is now complete as at least one Topic Filter is set.
      * @since 1.2
      */
-    @NotNull C addTopicFilters(@NotNull Collection<@NotNull MqttTopicFilter> topicFilters);
+    @NotNull C addTopicFilters(@NotNull Collection<@NotNull ? extends MqttTopicFilter> topicFilters);
 
     /**
      * Adds a stream of {@link MqttTopicFilter Topic Filters} to the {@link Mqtt5Unsubscribe#getTopicFilters() list of
@@ -100,7 +100,7 @@ public interface Mqtt5UnsubscribeBuilderBase<C extends Mqtt5UnsubscribeBuilderBa
      * @return the builder that is now complete as at least one Topic Filter is set.
      * @since 1.2
      */
-    @NotNull C addTopicFilters(@NotNull Stream<@NotNull MqttTopicFilter> topicFilters);
+    @NotNull C addTopicFilters(@NotNull Stream<@NotNull ? extends MqttTopicFilter> topicFilters);
 
     /**
      * Reverses the subscriptions of a Subscribe message by adding their Topic Filters.


### PR DESCRIPTION
**Motivation**
"add all" builder methods should consume Collections and Streams with subclass elements.

**Changes**
- Improved generics on "add all" builder methods
- Added missing CheckReturnValue annotations