### PR TITLE
Improvement/reactor adapter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,11 +59,11 @@ allprojects {
 }
 
 ext {
-    rxJavaVersion = '2.2.5'
-    nettyVersion = '4.1.32.Final'
-    daggerVersion = '2.20'
+    rxJavaVersion = '2.2.19'
+    nettyVersion = '4.1.48.Final'
+    daggerVersion = '2.27'
     jcToolsVersion = '2.1.2'
-    slf4jVersion = '1.7.25'
+    slf4jVersion = '1.7.30'
     jetbrainsAnnotationsVersion = '16.0.3'
 }
 

--- a/reactor/build.gradle
+++ b/reactor/build.gradle
@@ -12,11 +12,12 @@ ext {
 
 dependencies {
     api rootProject
-    api group: 'io.projectreactor', name: 'reactor-core', version: '3.3.1.RELEASE'
+    api group: 'io.projectreactor', name: 'reactor-core', version: '3.3.4.RELEASE'
+    implementation group: 'io.projectreactor.addons', name: 'reactor-adapter', version: '3.3.3.RELEASE'
     implementation group: 'org.jetbrains', name: 'annotations', version: jetbrainsAnnotationsVersion
 }
 
 dependencies {
-    testImplementation group: 'io.projectreactor', name: 'reactor-test', version: '3.3.1.RELEASE'
+    testImplementation group: 'io.projectreactor', name: 'reactor-test', version: '3.3.4.RELEASE'
     testImplementation group: 'com.google.guava', name: 'guava', version: '24.1-jre'
 }

--- a/reactor/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/reactor/Mqtt3ReactorClientView.java
+++ b/reactor/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/reactor/Mqtt3ReactorClientView.java
@@ -29,12 +29,12 @@ import com.hivemq.client.mqtt.mqtt3.message.publish.Mqtt3PublishResult;
 import com.hivemq.client.mqtt.mqtt3.message.subscribe.Mqtt3Subscribe;
 import com.hivemq.client.mqtt.mqtt3.message.subscribe.suback.Mqtt3SubAck;
 import com.hivemq.client.mqtt.mqtt3.message.unsubscribe.Mqtt3Unsubscribe;
-import com.hivemq.client.mqtt.mqtt3.message.unsubscribe.unsuback.Mqtt3UnsubAck;
 import com.hivemq.client.mqtt.mqtt3.reactor.Mqtt3ReactorClient;
 import com.hivemq.client.rx.reactor.FluxWithSingle;
 import io.reactivex.Flowable;
 import org.jetbrains.annotations.NotNull;
 import org.reactivestreams.Publisher;
+import reactor.adapter.rxjava.RxJava2Adapter;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -50,11 +50,11 @@ public class Mqtt3ReactorClientView implements Mqtt3ReactorClient {
     }
 
     public @NotNull Mono<Mqtt3ConnAck> connect(final @NotNull Mqtt3Connect connect) {
-        return Mono.fromDirect(delegate.connect(connect).toFlowable());
+        return RxJava2Adapter.singleToMono(delegate.connect(connect));
     }
 
     public @NotNull Mono<Mqtt3SubAck> subscribe(final @NotNull Mqtt3Subscribe subscribe) {
-        return Mono.fromDirect(delegate.subscribe(subscribe).toFlowable());
+        return RxJava2Adapter.singleToMono(delegate.subscribe(subscribe));
     }
 
     public @NotNull FluxWithSingle<Mqtt3Publish, Mqtt3SubAck> subscribeStream(final @NotNull Mqtt3Subscribe subscribe) {
@@ -62,19 +62,19 @@ public class Mqtt3ReactorClientView implements Mqtt3ReactorClient {
     }
 
     public @NotNull Flux<Mqtt3Publish> publishes(final @NotNull MqttGlobalPublishFilter filter) {
-        return Flux.from(delegate.publishes(filter));
+        return RxJava2Adapter.flowableToFlux(delegate.publishes(filter));
     }
 
-    public @NotNull Mono<Mqtt3UnsubAck> unsubscribe(final @NotNull Mqtt3Unsubscribe unsubscribe) {
-        return Mono.fromDirect(delegate.unsubscribe(unsubscribe).toFlowable());
+    public @NotNull Mono<Void> unsubscribe(final @NotNull Mqtt3Unsubscribe unsubscribe) {
+        return RxJava2Adapter.completableToMono(delegate.unsubscribe(unsubscribe));
     }
 
     public @NotNull Flux<Mqtt3PublishResult> publish(final @NotNull Publisher<Mqtt3Publish> publisher) {
-        return Flux.from(delegate.publish(Flowable.fromPublisher(publisher)));
+        return RxJava2Adapter.flowableToFlux(delegate.publish(Flowable.fromPublisher(publisher)));
     }
 
     public @NotNull Mono<Void> disconnect() {
-        return Mono.fromDirect(delegate.disconnect().toFlowable());
+        return RxJava2Adapter.completableToMono(delegate.disconnect());
     }
 
     @Override

--- a/reactor/src/main/java/com/hivemq/client/internal/mqtt/reactor/MqttReactorClient.java
+++ b/reactor/src/main/java/com/hivemq/client/internal/mqtt/reactor/MqttReactorClient.java
@@ -36,6 +36,7 @@ import com.hivemq.client.rx.reactor.FluxWithSingle;
 import io.reactivex.Flowable;
 import org.jetbrains.annotations.NotNull;
 import org.reactivestreams.Publisher;
+import reactor.adapter.rxjava.RxJava2Adapter;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -51,11 +52,11 @@ public class MqttReactorClient implements Mqtt5ReactorClient {
     }
 
     public @NotNull Mono<Mqtt5ConnAck> connect(final @NotNull Mqtt5Connect connect) {
-        return Mono.fromDirect(delegate.connect(connect).toFlowable());
+        return RxJava2Adapter.singleToMono(delegate.connect(connect));
     }
 
     public @NotNull Mono<Mqtt5SubAck> subscribe(final @NotNull Mqtt5Subscribe subscribe) {
-        return Mono.fromDirect(delegate.subscribe(subscribe).toFlowable());
+        return RxJava2Adapter.singleToMono(delegate.subscribe(subscribe));
     }
 
     public @NotNull FluxWithSingle<Mqtt5Publish, Mqtt5SubAck> subscribeStream(final @NotNull Mqtt5Subscribe subscribe) {
@@ -63,23 +64,23 @@ public class MqttReactorClient implements Mqtt5ReactorClient {
     }
 
     public @NotNull Flux<Mqtt5Publish> publishes(final @NotNull MqttGlobalPublishFilter filter) {
-        return Flux.from(delegate.publishes(filter));
+        return RxJava2Adapter.flowableToFlux(delegate.publishes(filter));
     }
 
     public @NotNull Mono<Mqtt5UnsubAck> unsubscribe(final @NotNull Mqtt5Unsubscribe unsubscribe) {
-        return Mono.fromDirect(delegate.unsubscribe(unsubscribe).toFlowable());
+        return RxJava2Adapter.singleToMono(delegate.unsubscribe(unsubscribe));
     }
 
     public @NotNull Flux<Mqtt5PublishResult> publish(final @NotNull Publisher<Mqtt5Publish> publisher) {
-        return Flux.from(delegate.publish(Flowable.fromPublisher(publisher)));
+        return RxJava2Adapter.flowableToFlux(delegate.publish(Flowable.fromPublisher(publisher)));
     }
 
     public @NotNull Mono<Void> reauth() {
-        return Mono.fromDirect(delegate.reauth().toFlowable());
+        return RxJava2Adapter.completableToMono(delegate.reauth());
     }
 
     public @NotNull Mono<Void> disconnect(final @NotNull Mqtt5Disconnect disconnect) {
-        return Mono.fromDirect(delegate.disconnect(disconnect).toFlowable());
+        return RxJava2Adapter.completableToMono(delegate.disconnect(disconnect));
     }
 
     @Override

--- a/reactor/src/main/java/com/hivemq/client/mqtt/mqtt3/reactor/Mqtt3ReactorClient.java
+++ b/reactor/src/main/java/com/hivemq/client/mqtt/mqtt3/reactor/Mqtt3ReactorClient.java
@@ -35,7 +35,6 @@ import com.hivemq.client.mqtt.mqtt3.message.subscribe.Mqtt3SubscribeBuilder;
 import com.hivemq.client.mqtt.mqtt3.message.subscribe.suback.Mqtt3SubAck;
 import com.hivemq.client.mqtt.mqtt3.message.unsubscribe.Mqtt3Unsubscribe;
 import com.hivemq.client.mqtt.mqtt3.message.unsubscribe.Mqtt3UnsubscribeBuilder;
-import com.hivemq.client.mqtt.mqtt3.message.unsubscribe.unsuback.Mqtt3UnsubAck;
 import com.hivemq.client.rx.reactor.FluxWithSingle;
 import org.jetbrains.annotations.NotNull;
 import org.reactivestreams.Publisher;
@@ -220,7 +219,7 @@ public interface Mqtt3ReactorClient extends Mqtt3Client {
      *         received.</li>
      *         </ul>
      */
-    @NotNull Mono<Mqtt3UnsubAck> unsubscribe(@NotNull Mqtt3Unsubscribe unsubscribe);
+    @NotNull Mono<Void> unsubscribe(@NotNull Mqtt3Unsubscribe unsubscribe);
 
     /**
      * Fluent counterpart of {@link #unsubscribe(Mqtt3Unsubscribe)}.
@@ -232,7 +231,7 @@ public interface Mqtt3ReactorClient extends Mqtt3Client {
      * @return the fluent builder for the Unsubscribe message.
      * @see #unsubscribe(Mqtt3Unsubscribe)
      */
-    default @NotNull Mqtt3UnsubscribeBuilder.Nested.Start<Mono<Mqtt3UnsubAck>> unsubscribeWith() {
+    default @NotNull Mqtt3UnsubscribeBuilder.Nested.Start<Mono<Void>> unsubscribeWith() {
         return new Mqtt3UnsubscribeViewBuilder.Nested<>(this::unsubscribe);
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3RxClient.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3RxClient.java
@@ -192,14 +192,14 @@ public interface Mqtt3RxClient extends Mqtt3Client {
     @NotNull Flowable<Mqtt3Publish> publishes(@NotNull MqttGlobalPublishFilter filter);
 
     /**
-     * Creates a {@link Single} for unsubscribing this client with the given Unsubscribe message.
+     * Creates a {@link Completable} for unsubscribing this client with the given Unsubscribe message.
      * <p>
-     * The returned {@link Single} represents the source of the UnsubAck message corresponding to the given Unsubscribe
-     * message. Calling this method does not unsubscribe yet. Unsubscribing is performed lazy and asynchronous when
-     * subscribing (in terms of Reactive Streams) to the returned {@link Single}.
+     * The returned {@link Completable} represents the source of the UnsubAck message corresponding to the given
+     * Unsubscribe message. Calling this method does not unsubscribe yet. Unsubscribing is performed lazy and
+     * asynchronous when subscribing (in terms of Reactive Streams) to the returned {@link Completable}.
      *
      * @param unsubscribe the Unsubscribe message sent to the broker during unsubscribe.
-     * @return the {@link Single} which
+     * @return the {@link Completable} which
      *         <ul>
      *         <li>succeeds when the corresponding UnsubAck message was received or</li>
      *         <li>errors if an error occurred before the Unsubscribe message was sent or before a UnsubAck message was


### PR DESCRIPTION
**Motivation**
Reactor has an adapter library for RxJava that we should use for the reactor API.

**Changes**
- Use io.projectreactor.addons:reactor-adapter
- Updated dependency versions for 1.2 release