### PR TITLE
Cleaned up annotation placement for nested classes

### DIFF
--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttAsyncClient.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttAsyncClient.java
@@ -117,7 +117,7 @@ public class MqttAsyncClient implements Mqtt5AsyncClient {
     }
 
     @Override
-    public @NotNull MqttConnectBuilder.Send<CompletableFuture<Mqtt5ConnAck>> connectWith() {
+    public MqttConnectBuilder.@NotNull Send<CompletableFuture<Mqtt5ConnAck>> connectWith() {
         return new MqttConnectBuilder.Send<>(this::connect);
     }
 
@@ -232,7 +232,7 @@ public class MqttAsyncClient implements Mqtt5AsyncClient {
     }
 
     @Override
-    public @NotNull MqttUnsubscribeBuilder.Send<CompletableFuture<Mqtt5UnsubAck>> unsubscribeWith() {
+    public MqttUnsubscribeBuilder.@NotNull Send<CompletableFuture<Mqtt5UnsubAck>> unsubscribeWith() {
         return new MqttUnsubscribeBuilder.Send<>(this::unsubscribe);
     }
 
@@ -244,7 +244,7 @@ public class MqttAsyncClient implements Mqtt5AsyncClient {
     }
 
     @Override
-    public @NotNull MqttPublishBuilder.Send<CompletableFuture<Mqtt5PublishResult>> publishWith() {
+    public MqttPublishBuilder.@NotNull Send<CompletableFuture<Mqtt5PublishResult>> publishWith() {
         return new MqttPublishBuilder.Send<>(this::publish);
     }
 
@@ -266,7 +266,7 @@ public class MqttAsyncClient implements Mqtt5AsyncClient {
     }
 
     @Override
-    public @NotNull MqttDisconnectBuilder.Send<CompletableFuture<Void>> disconnectWith() {
+    public MqttDisconnectBuilder.@NotNull Send<CompletableFuture<Void>> disconnectWith() {
         return new MqttDisconnectBuilder.Send<>(this::disconnect);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttBlockingClient.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttBlockingClient.java
@@ -103,7 +103,7 @@ public class MqttBlockingClient implements Mqtt5BlockingClient {
     }
 
     @Override
-    public @NotNull MqttConnectBuilder.Send<Mqtt5ConnAck> connectWith() {
+    public MqttConnectBuilder.@NotNull Send<Mqtt5ConnAck> connectWith() {
         return new MqttConnectBuilder.Send<>(this::connect);
     }
 
@@ -121,7 +121,7 @@ public class MqttBlockingClient implements Mqtt5BlockingClient {
     }
 
     @Override
-    public @NotNull MqttSubscribeBuilder.Send<Mqtt5SubAck> subscribeWith() {
+    public MqttSubscribeBuilder.@NotNull Send<Mqtt5SubAck> subscribeWith() {
         return new MqttSubscribeBuilder.Send<>(this::subscribe);
     }
 
@@ -153,7 +153,7 @@ public class MqttBlockingClient implements Mqtt5BlockingClient {
     }
 
     @Override
-    public @NotNull MqttUnsubscribeBuilder.Send<Mqtt5UnsubAck> unsubscribeWith() {
+    public MqttUnsubscribeBuilder.@NotNull Send<Mqtt5UnsubAck> unsubscribeWith() {
         return new MqttUnsubscribeBuilder.Send<>(this::unsubscribe);
     }
 
@@ -168,7 +168,7 @@ public class MqttBlockingClient implements Mqtt5BlockingClient {
     }
 
     @Override
-    public @NotNull MqttPublishBuilder.Send<Mqtt5PublishResult> publishWith() {
+    public MqttPublishBuilder.@NotNull Send<Mqtt5PublishResult> publishWith() {
         return new MqttPublishBuilder.Send<>(this::publish);
     }
 
@@ -197,7 +197,7 @@ public class MqttBlockingClient implements Mqtt5BlockingClient {
     }
 
     @Override
-    public @NotNull MqttDisconnectBuilder.SendVoid disconnectWith() {
+    public MqttDisconnectBuilder.@NotNull SendVoid disconnectWith() {
         return new MqttDisconnectBuilder.SendVoid(this::disconnect);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttClientExecutorConfigImpl.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttClientExecutorConfigImpl.java
@@ -73,7 +73,7 @@ public class MqttClientExecutorConfigImpl implements MqttClientExecutorConfig {
     }
 
     @Override
-    public @NotNull MqttClientExecutorConfigImplBuilder.Default extend() {
+    public MqttClientExecutorConfigImplBuilder.@NotNull Default extend() {
         return new MqttClientExecutorConfigImplBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttClientSslConfigImpl.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttClientSslConfigImpl.java
@@ -122,7 +122,7 @@ public class MqttClientSslConfigImpl implements MqttClientSslConfig {
     }
 
     @Override
-    public @NotNull MqttClientSslConfigImplBuilder.Default extend() {
+    public MqttClientSslConfigImplBuilder.@NotNull Default extend() {
         return new MqttClientSslConfigImplBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttClientTransportConfigImpl.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttClientTransportConfigImpl.java
@@ -116,7 +116,7 @@ public class MqttClientTransportConfigImpl implements MqttClientTransportConfig 
     }
 
     @Override
-    public @NotNull MqttClientTransportConfigImplBuilder.Default extend() {
+    public MqttClientTransportConfigImplBuilder.@NotNull Default extend() {
         return new MqttClientTransportConfigImplBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttClientTransportConfigImplBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttClientTransportConfigImplBuilder.java
@@ -187,7 +187,7 @@ public abstract class MqttClientTransportConfigImplBuilder<B extends MqttClientT
         return self();
     }
 
-    public @NotNull MqttClientSslConfigImplBuilder.Nested<B> sslConfig() {
+    public MqttClientSslConfigImplBuilder.@NotNull Nested<B> sslConfig() {
         return new MqttClientSslConfigImplBuilder.Nested<>(sslConfig, this::sslConfig);
     }
 
@@ -202,7 +202,7 @@ public abstract class MqttClientTransportConfigImplBuilder<B extends MqttClientT
         return self();
     }
 
-    public @NotNull MqttWebSocketConfigImplBuilder.Nested<B> webSocketConfig() {
+    public MqttWebSocketConfigImplBuilder.@NotNull Nested<B> webSocketConfig() {
         return new MqttWebSocketConfigImplBuilder.Nested<>(webSocketConfig, this::webSocketConfig);
     }
 
@@ -211,7 +211,7 @@ public abstract class MqttClientTransportConfigImplBuilder<B extends MqttClientT
         return self();
     }
 
-    public @NotNull MqttProxyConfigImplBuilder.Nested<B> proxyConfig() {
+    public MqttProxyConfigImplBuilder.@NotNull Nested<B> proxyConfig() {
         return new MqttProxyConfigImplBuilder.Nested<>(proxyConfig, this::proxyConfig);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttProxyConfigImpl.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttProxyConfigImpl.java
@@ -84,7 +84,7 @@ public class MqttProxyConfigImpl implements MqttProxyConfig {
     }
 
     @Override
-    public @NotNull MqttProxyConfigImplBuilder.Default extend() {
+    public MqttProxyConfigImplBuilder.@NotNull Default extend() {
         return new MqttProxyConfigImplBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttRxClient.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttRxClient.java
@@ -90,7 +90,7 @@ public class MqttRxClient implements Mqtt5RxClient {
     }
 
     @Override
-    public @NotNull MqttConnectBuilder.Nested<Single<Mqtt5ConnAck>> connectWith() {
+    public MqttConnectBuilder.@NotNull Nested<Single<Mqtt5ConnAck>> connectWith() {
         return new MqttConnectBuilder.Nested<>(this::connect);
     }
 
@@ -108,7 +108,7 @@ public class MqttRxClient implements Mqtt5RxClient {
     }
 
     @Override
-    public @NotNull MqttSubscribeBuilder.Nested<Single<Mqtt5SubAck>> subscribeWith() {
+    public MqttSubscribeBuilder.@NotNull Nested<Single<Mqtt5SubAck>> subscribeWith() {
         return new MqttSubscribeBuilder.Nested<>(this::subscribe);
     }
 
@@ -120,7 +120,7 @@ public class MqttRxClient implements Mqtt5RxClient {
     }
 
     @Override
-    public @NotNull MqttSubscribeBuilder.Nested<FlowableWithSingle<Mqtt5Publish, Mqtt5SubAck>> subscribeStreamWith() {
+    public MqttSubscribeBuilder.@NotNull Nested<FlowableWithSingle<Mqtt5Publish, Mqtt5SubAck>> subscribeStreamWith() {
         return new MqttSubscribeBuilder.Nested<>(this::subscribeStream);
     }
 
@@ -191,7 +191,7 @@ public class MqttRxClient implements Mqtt5RxClient {
     }
 
     @Override
-    public @NotNull MqttUnsubscribeBuilder.Nested<Single<Mqtt5UnsubAck>> unsubscribeWith() {
+    public MqttUnsubscribeBuilder.@NotNull Nested<Single<Mqtt5UnsubAck>> unsubscribeWith() {
         return new MqttUnsubscribeBuilder.Nested<>(this::unsubscribe);
     }
 
@@ -261,7 +261,7 @@ public class MqttRxClient implements Mqtt5RxClient {
     }
 
     @Override
-    public @NotNull MqttDisconnectBuilder.Nested<Completable> disconnectWith() {
+    public MqttDisconnectBuilder.@NotNull Nested<Completable> disconnectWith() {
         return new MqttDisconnectBuilder.Nested<>(this::disconnect);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttRxClientBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttRxClientBuilder.java
@@ -61,7 +61,7 @@ public class MqttRxClientBuilder extends MqttRxClientBuilderBase<MqttRxClientBui
     }
 
     @Override
-    public @NotNull MqttClientAdvancedConfigBuilder.Nested<MqttRxClientBuilder> advancedConfig() {
+    public MqttClientAdvancedConfigBuilder.@NotNull Nested<MqttRxClientBuilder> advancedConfig() {
         return new MqttClientAdvancedConfigBuilder.Nested<>(advancedConfig, this::advancedConfig);
     }
 
@@ -72,7 +72,7 @@ public class MqttRxClientBuilder extends MqttRxClientBuilderBase<MqttRxClientBui
     }
 
     @Override
-    public @NotNull MqttSimpleAuthBuilder.Nested<MqttRxClientBuilder> simpleAuth() {
+    public MqttSimpleAuthBuilder.@NotNull Nested<MqttRxClientBuilder> simpleAuth() {
         return new MqttSimpleAuthBuilder.Nested<>(this::simpleAuth);
     }
 
@@ -90,7 +90,7 @@ public class MqttRxClientBuilder extends MqttRxClientBuilderBase<MqttRxClientBui
     }
 
     @Override
-    public @NotNull MqttPublishBuilder.WillNested<MqttRxClientBuilder> willPublish() {
+    public MqttPublishBuilder.@NotNull WillNested<MqttRxClientBuilder> willPublish() {
         return new MqttPublishBuilder.WillNested<>(this::willPublish);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttRxClientBuilderBase.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttRxClientBuilderBase.java
@@ -46,8 +46,8 @@ public abstract class MqttRxClientBuilderBase<B extends MqttRxClientBuilderBase<
     private @Nullable MqttClientTransportConfigImpl transportConfig = MqttClientTransportConfigImpl.DEFAULT;
     private @NotNull MqttClientExecutorConfigImpl executorConfig = MqttClientExecutorConfigImpl.DEFAULT;
     private @Nullable MqttClientAutoReconnectImpl autoReconnect;
-    private @Nullable ImmutableList.Builder<MqttClientConnectedListener> connectedListenersBuilder;
-    private @Nullable ImmutableList.Builder<MqttClientDisconnectedListener> disconnectedListenersBuilder;
+    private ImmutableList.@Nullable Builder<MqttClientConnectedListener> connectedListenersBuilder;
+    private ImmutableList.@Nullable Builder<MqttClientDisconnectedListener> disconnectedListenersBuilder;
 
     protected MqttRxClientBuilderBase() {}
 
@@ -127,7 +127,7 @@ public abstract class MqttRxClientBuilderBase<B extends MqttRxClientBuilderBase<
         return self();
     }
 
-    public @NotNull MqttClientTransportConfigImplBuilder.Nested<B> transportConfig() {
+    public MqttClientTransportConfigImplBuilder.@NotNull Nested<B> transportConfig() {
         return new MqttClientTransportConfigImplBuilder.Nested<>(this, this::transportConfig);
     }
 
@@ -137,7 +137,7 @@ public abstract class MqttRxClientBuilderBase<B extends MqttRxClientBuilderBase<
         return self();
     }
 
-    public @NotNull MqttClientExecutorConfigImplBuilder.Nested<B> executorConfig() {
+    public MqttClientExecutorConfigImplBuilder.@NotNull Nested<B> executorConfig() {
         return new MqttClientExecutorConfigImplBuilder.Nested<>(executorConfig, this::executorConfig);
     }
 
@@ -152,7 +152,7 @@ public abstract class MqttRxClientBuilderBase<B extends MqttRxClientBuilderBase<
         return self();
     }
 
-    public @NotNull MqttClientAutoReconnectImplBuilder.Nested<B> automaticReconnect() {
+    public MqttClientAutoReconnectImplBuilder.@NotNull Nested<B> automaticReconnect() {
         return new MqttClientAutoReconnectImplBuilder.Nested<>(autoReconnect, this::automaticReconnect);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttWebSocketConfigImpl.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttWebSocketConfigImpl.java
@@ -68,7 +68,7 @@ public class MqttWebSocketConfigImpl implements MqttWebSocketConfig {
     }
 
     @Override
-    public @NotNull MqttWebSocketConfigImplBuilder.Default extend() {
+    public MqttWebSocketConfigImplBuilder.@NotNull Default extend() {
         return new MqttWebSocketConfigImplBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/advanced/MqttClientAdvancedConfig.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/advanced/MqttClientAdvancedConfig.java
@@ -60,7 +60,7 @@ public class MqttClientAdvancedConfig implements Mqtt5ClientAdvancedConfig {
     }
 
     @Override
-    public @NotNull MqttClientAdvancedConfigBuilder.Default extend() {
+    public MqttClientAdvancedConfigBuilder.@NotNull Default extend() {
         return new MqttClientAdvancedConfigBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/advanced/MqttClientAdvancedConfigBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/advanced/MqttClientAdvancedConfigBuilder.java
@@ -60,7 +60,7 @@ public abstract class MqttClientAdvancedConfigBuilder<B extends MqttClientAdvanc
         return self();
     }
 
-    public @NotNull MqttClientInterceptorsBuilder.Nested<B> interceptors() {
+    public MqttClientInterceptorsBuilder.@NotNull Nested<B> interceptors() {
         return new MqttClientInterceptorsBuilder.Nested<>(interceptors, this::interceptors);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/advanced/interceptor/MqttClientInterceptors.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/advanced/interceptor/MqttClientInterceptors.java
@@ -69,7 +69,7 @@ public class MqttClientInterceptors implements Mqtt5ClientInterceptors {
     }
 
     @Override
-    public @NotNull MqttClientInterceptorsBuilder.Default extend() {
+    public MqttClientInterceptorsBuilder.@NotNull Default extend() {
         return new MqttClientInterceptorsBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttSharedTopicFilterImpl.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttSharedTopicFilterImpl.java
@@ -276,7 +276,7 @@ public class MqttSharedTopicFilterImpl extends MqttTopicFilterImpl implements Mq
     }
 
     @Override
-    public @NotNull MqttTopicFilterImplBuilder.SharedDefault extendShared() {
+    public MqttTopicFilterImplBuilder.@NotNull SharedDefault extendShared() {
         return new MqttTopicFilterImplBuilder.SharedDefault(this);
     }
 }

--- a/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttTopicFilterImpl.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttTopicFilterImpl.java
@@ -372,7 +372,7 @@ public class MqttTopicFilterImpl extends MqttUtf8StringImpl implements MqttTopic
     }
 
     @Override
-    public @NotNull MqttTopicFilterImplBuilder.Default extend() {
+    public MqttTopicFilterImplBuilder.@NotNull Default extend() {
         return new MqttTopicFilterImplBuilder.Default(this);
     }
 }

--- a/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttTopicFilterImplBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttTopicFilterImplBuilder.java
@@ -110,9 +110,8 @@ public abstract class MqttTopicFilterImplBuilder<B extends MqttTopicFilterImplBu
             return this;
         }
 
-        @NotNull
         @Override
-        public SharedDefault share(final @Nullable String shareName) {
+        public @NotNull SharedDefault share(final @Nullable String shareName) {
             if (stringBuilder == null) {
                 return new SharedDefault(shareName);
             }

--- a/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttTopicImpl.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttTopicImpl.java
@@ -187,7 +187,7 @@ public class MqttTopicImpl extends MqttUtf8StringImpl implements MqttTopic {
     }
 
     @Override
-    public @NotNull MqttTopicImplBuilder.Default extend() {
+    public MqttTopicImplBuilder.@NotNull Default extend() {
         return new MqttTopicImplBuilder.Default(this);
     }
 }

--- a/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttTopicImplBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttTopicImplBuilder.java
@@ -69,7 +69,7 @@ public abstract class MqttTopicImplBuilder<B extends MqttTopicImplBuilder<B>> {
         }
 
         @Override
-        public @NotNull MqttTopicFilterImplBuilder.Default filter() {
+        public MqttTopicFilterImplBuilder.@NotNull Default filter() {
             if (stringBuilder == null) {
                 return new MqttTopicFilterImplBuilder.Default();
             }
@@ -77,7 +77,7 @@ public abstract class MqttTopicImplBuilder<B extends MqttTopicImplBuilder<B>> {
         }
 
         @Override
-        public @NotNull MqttTopicFilterImplBuilder.SharedDefault share(final @Nullable String shareName) {
+        public MqttTopicFilterImplBuilder.@NotNull SharedDefault share(final @Nullable String shareName) {
             if (stringBuilder == null) {
                 return new MqttTopicFilterImplBuilder.SharedDefault(shareName);
             }

--- a/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttUserPropertiesImpl.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttUserPropertiesImpl.java
@@ -126,7 +126,7 @@ public class MqttUserPropertiesImpl implements Mqtt5UserProperties {
     }
 
     @Override
-    public @NotNull MqttUserPropertiesImplBuilder.Default extend() {
+    public MqttUserPropertiesImplBuilder.@NotNull Default extend() {
         return new MqttUserPropertiesImplBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttUserPropertiesImplBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/datatypes/MqttUserPropertiesImplBuilder.java
@@ -34,7 +34,7 @@ import java.util.stream.Stream;
  */
 public abstract class MqttUserPropertiesImplBuilder<B extends MqttUserPropertiesImplBuilder<B>> {
 
-    private final @NotNull ImmutableList.Builder<MqttUserPropertyImpl> listBuilder;
+    private final ImmutableList.@NotNull Builder<MqttUserPropertyImpl> listBuilder;
 
     MqttUserPropertiesImplBuilder() {
         listBuilder = ImmutableList.builder();

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/disconnect/MqttDisconnectHandler.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/disconnect/MqttDisconnectHandler.java
@@ -260,10 +260,10 @@ public class MqttDisconnectHandler extends MqttConnectionAwareHandler {
     private static class DisconnectingState implements Runnable {
 
         private final @NotNull Channel channel;
-        private final @NotNull MqttDisconnectEvent.ByUser disconnectEvent;
+        private final MqttDisconnectEvent.@NotNull ByUser disconnectEvent;
         private final @NotNull ScheduledFuture<?> timeoutFuture;
 
-        DisconnectingState(final @NotNull Channel channel, final @NotNull MqttDisconnectEvent.ByUser disconnectEvent) {
+        DisconnectingState(final @NotNull Channel channel, final MqttDisconnectEvent.@NotNull ByUser disconnectEvent) {
             this.channel = channel;
             this.disconnectEvent = disconnectEvent;
             timeoutFuture = channel.eventLoop().schedule(this, DISCONNECT_TIMEOUT, TimeUnit.SECONDS);

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/incoming/MqttIncomingPublishService.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/incoming/MqttIncomingPublishService.java
@@ -42,9 +42,9 @@ class MqttIncomingPublishService {
     final @NotNull MqttIncomingPublishFlows incomingPublishFlows;
 
     private final @NotNull ChunkedArrayQueue<Object> qos0Queue = new ChunkedArrayQueue<>(32);
-    private final @NotNull ChunkedArrayQueue<Object>.Iterator qos0It = qos0Queue.iterator();
+    private final ChunkedArrayQueue<Object>.@NotNull Iterator qos0It = qos0Queue.iterator();
     private final @NotNull ChunkedArrayQueue<Object> qos1Or2Queue = new ChunkedArrayQueue<>(32);
-    private final @NotNull ChunkedArrayQueue<Object>.Iterator qos1Or2It = qos1Or2Queue.iterator();
+    private final ChunkedArrayQueue<Object>.@NotNull Iterator qos1Or2It = qos1Or2Queue.iterator();
 
     private long nextQoS1Or2PublishId = 1;
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/incoming/MqttIncomingQosHandler.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/incoming/MqttIncomingQosHandler.java
@@ -54,7 +54,7 @@ public class MqttIncomingQosHandler extends MqttSessionAwareHandler
         implements ContextFuture.Listener<MqttMessage.WithId> {
 
     public static final @NotNull String NAME = "qos.incoming";
-    private static final @NotNull IntIndex.Spec<MqttMessage.WithId> INDEX_SPEC =
+    private static final IntIndex.@NotNull Spec<MqttMessage.WithId> INDEX_SPEC =
             new IntIndex.Spec<>(MqttMessage.WithId::getPacketIdentifier);
 
     private final @NotNull MqttClientConfig clientConfig;

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/incoming/MqttSubscribedPublishFlowTree.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/incoming/MqttSubscribedPublishFlowTree.java
@@ -154,7 +154,7 @@ public class MqttSubscribedPublishFlowTree implements MqttSubscribedPublishFlows
 
     private static class TopicTreeNode {
 
-        private static final @NotNull Index.Spec<TopicTreeNode, MqttTopicLevel> INDEX_SPEC =
+        private static final Index.@NotNull Spec<TopicTreeNode, MqttTopicLevel> INDEX_SPEC =
                 new Index.Spec<>(node -> node.topicLevel, 4);
 
         private @Nullable TopicTreeNode parent;

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttOutgoingQosHandler.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttOutgoingQosHandler.java
@@ -80,7 +80,7 @@ public class MqttOutgoingQosHandler extends MqttSessionAwareHandler
 
     public static final @NotNull String NAME = "qos.outgoing";
     private static final @NotNull InternalLogger LOGGER = InternalLoggerFactory.getLogger(MqttOutgoingQosHandler.class);
-    private static final @NotNull IntIndex.Spec<MqttPubOrRelWithFlow> INDEX_SPEC =
+    private static final IntIndex.@NotNull Spec<MqttPubOrRelWithFlow> INDEX_SPEC =
             new IntIndex.Spec<>(x -> x.packetIdentifier);
     private static final int MAX_CONCURRENT_PUBLISH_FLOWABLES = 64; // TODO configurable
     private static final boolean QOS_2_COMPLETE_RESULT = false; // TODO configurable
@@ -226,7 +226,7 @@ public class MqttOutgoingQosHandler extends MqttSessionAwareHandler
     }
 
     @Override
-    public void channelWritabilityChanged(final ChannelHandlerContext ctx) {
+    public void channelWritabilityChanged(final @NotNull ChannelHandlerContext ctx) {
         final Channel channel = ctx.channel();
         if (channel.isWritable()) {
             channel.eventLoop().execute(this);

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttTopicAliasAutoMapping.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/publish/outgoing/MqttTopicAliasAutoMapping.java
@@ -33,7 +33,7 @@ public class MqttTopicAliasAutoMapping implements MqttTopicAliasMapping {
     private static final byte OVERWRITE_COST_MIN = 2;
     private static final byte OVERWRITE_COST_MAX = 126;
     private static final byte OVERWRITE_COST_INC = 2;
-    private static final @NotNull Index.Spec<Entry, String> INDEX_SPEC = new Index.Spec<>(entry -> entry.topic);
+    private static final Index.@NotNull Spec<Entry, String> INDEX_SPEC = new Index.Spec<>(entry -> entry.topic);
 
     private final int topicAliasMaximum;
     private final @NotNull Index<Entry, String> map = new Index<>(INDEX_SPEC);

--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/subscribe/MqttSubscriptionHandler.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/subscribe/MqttSubscriptionHandler.java
@@ -64,7 +64,7 @@ public class MqttSubscriptionHandler extends MqttSessionAwareHandler implements 
     public static final @NotNull String NAME = "subscription";
     private static final @NotNull InternalLogger LOGGER =
             InternalLoggerFactory.getLogger(MqttSubscriptionHandler.class);
-    private static final @NotNull IntIndex.Spec<MqttSubOrUnsubWithFlow> INDEX_SPEC =
+    private static final IntIndex.@NotNull Spec<MqttSubOrUnsubWithFlow> INDEX_SPEC =
             new IntIndex.Spec<>(x -> x.packetIdentifier, 4);
     public static final int MAX_SUB_PENDING = 10; // TODO configurable
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/ioc/ClientComponent.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/ioc/ClientComponent.java
@@ -33,7 +33,7 @@ import org.jetbrains.annotations.NotNull;
 @ClientScope
 public interface ClientComponent {
 
-    @NotNull ConnectionComponent.Builder connectionComponentBuilder();
+    ConnectionComponent.@NotNull Builder connectionComponentBuilder();
 
     @NotNull MqttSubscriptionHandler subscriptionHandler();
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/ioc/SingletonComponent.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/ioc/SingletonComponent.java
@@ -32,5 +32,5 @@ public interface SingletonComponent {
 
     @NotNull SingletonComponent INSTANCE = DaggerSingletonComponent.create();
 
-    @NotNull ClientComponent.Builder clientComponentBuilder();
+    ClientComponent.@NotNull Builder clientComponentBuilder();
 }

--- a/src/main/java/com/hivemq/client/internal/mqtt/lifecycle/MqttClientAutoReconnectImpl.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/lifecycle/MqttClientAutoReconnectImpl.java
@@ -66,7 +66,7 @@ public class MqttClientAutoReconnectImpl implements MqttClientAutoReconnect {
     }
 
     @Override
-    public @NotNull MqttClientAutoReconnectImplBuilder.Default extend() {
+    public MqttClientAutoReconnectImplBuilder.@NotNull Default extend() {
         return new MqttClientAutoReconnectImplBuilder.Default(this);
     }
 }

--- a/src/main/java/com/hivemq/client/internal/mqtt/lifecycle/MqttClientReconnector.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/lifecycle/MqttClientReconnector.java
@@ -150,7 +150,7 @@ public class MqttClientReconnector implements Mqtt5ClientReconnector {
     }
 
     @Override
-    public @NotNull MqttClientTransportConfigImplBuilder.Nested<MqttClientReconnector> transportConfig() {
+    public MqttClientTransportConfigImplBuilder.@NotNull Nested<MqttClientReconnector> transportConfig() {
         checkInEventLoop();
         return new MqttClientTransportConfigImplBuilder.Nested<>(transportConfig, this::transportConfig);
     }
@@ -169,7 +169,7 @@ public class MqttClientReconnector implements Mqtt5ClientReconnector {
     }
 
     @Override
-    public @NotNull MqttConnectBuilder.Nested<MqttClientReconnector> connectWith() {
+    public MqttConnectBuilder.@NotNull Nested<MqttClientReconnector> connectWith() {
         checkInEventLoop();
         return new MqttConnectBuilder.Nested<>(connect, this::connect);
     }

--- a/src/main/java/com/hivemq/client/internal/mqtt/lifecycle/mqtt3/Mqtt3ClientReconnectorView.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/lifecycle/mqtt3/Mqtt3ClientReconnectorView.java
@@ -110,7 +110,7 @@ public class Mqtt3ClientReconnectorView implements Mqtt3ClientReconnector {
     }
 
     @Override
-    public @NotNull MqttClientTransportConfigImplBuilder.Nested<Mqtt3ClientReconnectorView> transportConfig() {
+    public MqttClientTransportConfigImplBuilder.@NotNull Nested<Mqtt3ClientReconnectorView> transportConfig() {
         return new MqttClientTransportConfigImplBuilder.Nested<>(getTransportConfig(), this::transportConfig);
     }
 
@@ -126,7 +126,7 @@ public class Mqtt3ClientReconnectorView implements Mqtt3ClientReconnector {
     }
 
     @Override
-    public @NotNull Mqtt3ConnectViewBuilder.Nested<Mqtt3ClientReconnectorView> connectWith() {
+    public Mqtt3ConnectViewBuilder.@NotNull Nested<Mqtt3ClientReconnectorView> connectWith() {
         return new Mqtt3ConnectViewBuilder.Nested<>(getConnect(), this::connect);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/auth/MqttAuthBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/auth/MqttAuthBuilder.java
@@ -79,7 +79,7 @@ public class MqttAuthBuilder implements Mqtt5AuthBuilder {
     }
 
     @Override
-    public @NotNull MqttUserPropertiesImplBuilder.Nested<MqttAuthBuilder> userProperties() {
+    public MqttUserPropertiesImplBuilder.@NotNull Nested<MqttAuthBuilder> userProperties() {
         return new MqttUserPropertiesImplBuilder.Nested<>(userProperties, this::userProperties);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/connect/MqttConnect.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/connect/MqttConnect.java
@@ -121,7 +121,7 @@ public class MqttConnect extends MqttMessageWithUserProperties implements Mqtt5C
     }
 
     @Override
-    public @NotNull MqttConnectBuilder.Default extend() {
+    public MqttConnectBuilder.@NotNull Default extend() {
         return new MqttConnectBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/connect/MqttConnectBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/connect/MqttConnectBuilder.java
@@ -95,7 +95,7 @@ public abstract class MqttConnectBuilder<B extends MqttConnectBuilder<B>> {
         return self();
     }
 
-    public @NotNull MqttConnectRestrictionsBuilder.Nested<B> restrictions() {
+    public MqttConnectRestrictionsBuilder.@NotNull Nested<B> restrictions() {
         return new MqttConnectRestrictionsBuilder.Nested<>(restrictions, this::restrictions);
     }
 
@@ -104,7 +104,7 @@ public abstract class MqttConnectBuilder<B extends MqttConnectBuilder<B>> {
         return self();
     }
 
-    public @NotNull MqttSimpleAuthBuilder.Nested<B> simpleAuth() {
+    public MqttSimpleAuthBuilder.@NotNull Nested<B> simpleAuth() {
         return new MqttSimpleAuthBuilder.Nested<>(this::simpleAuth);
     }
 
@@ -119,7 +119,7 @@ public abstract class MqttConnectBuilder<B extends MqttConnectBuilder<B>> {
         return self();
     }
 
-    public @NotNull MqttPublishBuilder.WillNested<B> willPublish() {
+    public MqttPublishBuilder.@NotNull WillNested<B> willPublish() {
         return new MqttPublishBuilder.WillNested<>(this::willPublish);
     }
 
@@ -128,7 +128,7 @@ public abstract class MqttConnectBuilder<B extends MqttConnectBuilder<B>> {
         return self();
     }
 
-    public @NotNull MqttUserPropertiesImplBuilder.Nested<B> userProperties() {
+    public MqttUserPropertiesImplBuilder.@NotNull Nested<B> userProperties() {
         return new MqttUserPropertiesImplBuilder.Nested<>(userProperties, this::userProperties);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/connect/mqtt3/Mqtt3ConnectView.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/connect/mqtt3/Mqtt3ConnectView.java
@@ -105,7 +105,7 @@ public class Mqtt3ConnectView implements Mqtt3Connect {
     }
 
     @Override
-    public @NotNull Mqtt3ConnectViewBuilder.Default extend() {
+    public Mqtt3ConnectViewBuilder.@NotNull Default extend() {
         return new Mqtt3ConnectViewBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/connect/mqtt3/Mqtt3ConnectViewBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/connect/mqtt3/Mqtt3ConnectViewBuilder.java
@@ -75,7 +75,7 @@ public abstract class Mqtt3ConnectViewBuilder<B extends Mqtt3ConnectViewBuilder<
         return self();
     }
 
-    public @NotNull Mqtt3SimpleAuthViewBuilder.Nested<B> simpleAuth() {
+    public Mqtt3SimpleAuthViewBuilder.@NotNull Nested<B> simpleAuth() {
         return new Mqtt3SimpleAuthViewBuilder.Nested<>(this::simpleAuth);
     }
 
@@ -85,7 +85,7 @@ public abstract class Mqtt3ConnectViewBuilder<B extends Mqtt3ConnectViewBuilder<
         return self();
     }
 
-    public @NotNull Mqtt3PublishViewBuilder.WillNested<B> willPublish() {
+    public Mqtt3PublishViewBuilder.@NotNull WillNested<B> willPublish() {
         return new Mqtt3PublishViewBuilder.WillNested<>(this::willPublish);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/disconnect/MqttDisconnect.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/disconnect/MqttDisconnect.java
@@ -78,7 +78,7 @@ public class MqttDisconnect extends MqttMessageWithUserProperties.WithReason.Wit
     }
 
     @Override
-    public @NotNull MqttDisconnectBuilder.Default extend() {
+    public MqttDisconnectBuilder.@NotNull Default extend() {
         return new MqttDisconnectBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/disconnect/MqttDisconnectBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/disconnect/MqttDisconnectBuilder.java
@@ -95,7 +95,7 @@ public abstract class MqttDisconnectBuilder<B extends MqttDisconnectBuilder<B>> 
         return self();
     }
 
-    public @NotNull MqttUserPropertiesImplBuilder.Nested<B> userProperties() {
+    public MqttUserPropertiesImplBuilder.@NotNull Nested<B> userProperties() {
         return new MqttUserPropertiesImplBuilder.Nested<>(userProperties, this::userProperties);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/publish/MqttPublish.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/publish/MqttPublish.java
@@ -181,7 +181,7 @@ public class MqttPublish extends MqttMessageWithUserProperties implements Mqtt5P
     }
 
     @Override
-    public @NotNull MqttPublishBuilder.Default extend() {
+    public MqttPublishBuilder.@NotNull Default extend() {
         return new MqttPublishBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/publish/MqttPublishBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/publish/MqttPublishBuilder.java
@@ -89,7 +89,7 @@ public abstract class MqttPublishBuilder<B extends MqttPublishBuilder<B>> {
         return self();
     }
 
-    public @NotNull MqttTopicImplBuilder.Nested<B> topic() {
+    public MqttTopicImplBuilder.@NotNull Nested<B> topic() {
         return new MqttTopicImplBuilder.Nested<>(this::topic);
     }
 
@@ -138,7 +138,7 @@ public abstract class MqttPublishBuilder<B extends MqttPublishBuilder<B>> {
         return self();
     }
 
-    public @NotNull MqttTopicImplBuilder.Nested<B> responseTopic() {
+    public MqttTopicImplBuilder.@NotNull Nested<B> responseTopic() {
         return new MqttTopicImplBuilder.Nested<>(this::responseTopic);
     }
 
@@ -157,7 +157,7 @@ public abstract class MqttPublishBuilder<B extends MqttPublishBuilder<B>> {
         return self();
     }
 
-    public @NotNull MqttUserPropertiesImplBuilder.Nested<B> userProperties() {
+    public MqttUserPropertiesImplBuilder.@NotNull Nested<B> userProperties() {
         return new MqttUserPropertiesImplBuilder.Nested<>(userProperties, this::userProperties);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/publish/MqttWillPublish.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/publish/MqttWillPublish.java
@@ -65,7 +65,7 @@ public class MqttWillPublish extends MqttPublish implements Mqtt5WillPublish {
     }
 
     @Override
-    public @NotNull MqttPublishBuilder.WillDefault extendAsWill() {
+    public MqttPublishBuilder.@NotNull WillDefault extendAsWill() {
         return new MqttPublishBuilder.WillDefault(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/publish/mqtt3/Mqtt3PublishView.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/publish/mqtt3/Mqtt3PublishView.java
@@ -130,7 +130,7 @@ public class Mqtt3PublishView implements Mqtt3Publish {
     }
 
     @Override
-    public @NotNull Mqtt3PublishViewBuilder.Default extend() {
+    public Mqtt3PublishViewBuilder.@NotNull Default extend() {
         return new Mqtt3PublishViewBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/publish/mqtt3/Mqtt3PublishViewBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/publish/mqtt3/Mqtt3PublishViewBuilder.java
@@ -66,7 +66,7 @@ public abstract class Mqtt3PublishViewBuilder<B extends Mqtt3PublishViewBuilder<
         return self();
     }
 
-    public @NotNull MqttTopicImplBuilder.Nested<B> topic() {
+    public MqttTopicImplBuilder.@NotNull Nested<B> topic() {
         return new MqttTopicImplBuilder.Nested<>(this::topic);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/publish/puback/MqttPubAckBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/publish/puback/MqttPubAckBuilder.java
@@ -68,7 +68,7 @@ public class MqttPubAckBuilder implements Mqtt5PubAckBuilder {
     }
 
     @Override
-    public @NotNull MqttUserPropertiesImplBuilder.Nested<MqttPubAckBuilder> userProperties() {
+    public MqttUserPropertiesImplBuilder.@NotNull Nested<MqttPubAckBuilder> userProperties() {
         return new MqttUserPropertiesImplBuilder.Nested<>(userProperties, this::userProperties);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/publish/pubcomp/MqttPubCompBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/publish/pubcomp/MqttPubCompBuilder.java
@@ -66,7 +66,7 @@ public class MqttPubCompBuilder implements Mqtt5PubCompBuilder {
     }
 
     @Override
-    public @NotNull MqttUserPropertiesImplBuilder.Nested<MqttPubCompBuilder> userProperties() {
+    public MqttUserPropertiesImplBuilder.@NotNull Nested<MqttPubCompBuilder> userProperties() {
         return new MqttUserPropertiesImplBuilder.Nested<>(userProperties, this::userProperties);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/publish/pubrec/MqttPubRecBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/publish/pubrec/MqttPubRecBuilder.java
@@ -68,7 +68,7 @@ public class MqttPubRecBuilder implements Mqtt5PubRecBuilder {
     }
 
     @Override
-    public @NotNull MqttUserPropertiesImplBuilder.Nested<MqttPubRecBuilder> userProperties() {
+    public MqttUserPropertiesImplBuilder.@NotNull Nested<MqttPubRecBuilder> userProperties() {
         return new MqttUserPropertiesImplBuilder.Nested<>(userProperties, this::userProperties);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/publish/pubrel/MqttPubRelBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/publish/pubrel/MqttPubRelBuilder.java
@@ -66,7 +66,7 @@ public class MqttPubRelBuilder implements Mqtt5PubRelBuilder {
     }
 
     @Override
-    public @NotNull MqttUserPropertiesImplBuilder.Nested<MqttPubRelBuilder> userProperties() {
+    public MqttUserPropertiesImplBuilder.@NotNull Nested<MqttPubRelBuilder> userProperties() {
         return new MqttUserPropertiesImplBuilder.Nested<>(userProperties, this::userProperties);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/MqttSubscribe.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/MqttSubscribe.java
@@ -51,7 +51,7 @@ public class MqttSubscribe extends MqttMessageWithUserProperties implements Mqtt
     }
 
     @Override
-    public @NotNull MqttSubscribeBuilder.Default extend() {
+    public MqttSubscribeBuilder.@NotNull Default extend() {
         return new MqttSubscribeBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/MqttSubscribeBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/MqttSubscribeBuilder.java
@@ -40,9 +40,9 @@ import java.util.stream.Stream;
  */
 public abstract class MqttSubscribeBuilder<B extends MqttSubscribeBuilder<B>> {
 
-    private final @NotNull ImmutableList.Builder<MqttSubscription> subscriptionsBuilder;
+    private final ImmutableList.@NotNull Builder<MqttSubscription> subscriptionsBuilder;
     private @NotNull MqttUserPropertiesImpl userProperties = MqttUserPropertiesImpl.NO_USER_PROPERTIES;
-    private @Nullable MqttSubscriptionBuilder.Default firstSubscriptionBuilder;
+    private MqttSubscriptionBuilder.@Nullable Default firstSubscriptionBuilder;
 
     protected MqttSubscribeBuilder() {
         subscriptionsBuilder = ImmutableList.builder();
@@ -62,7 +62,7 @@ public abstract class MqttSubscribeBuilder<B extends MqttSubscribeBuilder<B>> {
         return self();
     }
 
-    public @NotNull MqttSubscriptionBuilder.Nested<B> addSubscription() {
+    public MqttSubscriptionBuilder.@NotNull Nested<B> addSubscription() {
         return new MqttSubscriptionBuilder.Nested<>(this::addSubscription);
     }
 
@@ -101,11 +101,11 @@ public abstract class MqttSubscribeBuilder<B extends MqttSubscribeBuilder<B>> {
         return self();
     }
 
-    public @NotNull MqttUserPropertiesImplBuilder.Nested<B> userProperties() {
+    public MqttUserPropertiesImplBuilder.@NotNull Nested<B> userProperties() {
         return new MqttUserPropertiesImplBuilder.Nested<>(userProperties, this::userProperties);
     }
 
-    private @NotNull MqttSubscriptionBuilder.Default getFirstSubscriptionBuilder() {
+    private MqttSubscriptionBuilder.@NotNull Default getFirstSubscriptionBuilder() {
         if (firstSubscriptionBuilder == null) {
             firstSubscriptionBuilder = new MqttSubscriptionBuilder.Default();
         }
@@ -129,7 +129,7 @@ public abstract class MqttSubscribeBuilder<B extends MqttSubscribeBuilder<B>> {
         return self();
     }
 
-    public @NotNull MqttTopicFilterImplBuilder.Nested<B> topicFilter() {
+    public MqttTopicFilterImplBuilder.@NotNull Nested<B> topicFilter() {
         return new MqttTopicFilterImplBuilder.Nested<>(this::topicFilter);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/MqttSubscription.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/MqttSubscription.java
@@ -76,7 +76,7 @@ public class MqttSubscription implements Mqtt5Subscription {
     }
 
     @Override
-    public @NotNull MqttSubscriptionBuilder.Default extend() {
+    public MqttSubscriptionBuilder.@NotNull Default extend() {
         return new MqttSubscriptionBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/MqttSubscriptionBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/MqttSubscriptionBuilder.java
@@ -63,7 +63,7 @@ public abstract class MqttSubscriptionBuilder<B extends MqttSubscriptionBuilder<
         return self();
     }
 
-    public @NotNull MqttTopicFilterImplBuilder.Nested<B> topicFilter() {
+    public MqttTopicFilterImplBuilder.@NotNull Nested<B> topicFilter() {
         return new MqttTopicFilterImplBuilder.Nested<>(this::topicFilter);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeView.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeView.java
@@ -65,7 +65,7 @@ public class Mqtt3SubscribeView implements Mqtt3Subscribe {
     }
 
     @Override
-    public @NotNull Mqtt3SubscribeViewBuilder.Default extend() {
+    public Mqtt3SubscribeViewBuilder.@NotNull Default extend() {
         return new Mqtt3SubscribeViewBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeViewBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeViewBuilder.java
@@ -36,8 +36,8 @@ import java.util.stream.Stream;
  */
 public abstract class Mqtt3SubscribeViewBuilder<B extends Mqtt3SubscribeViewBuilder<B>> {
 
-    private final @NotNull ImmutableList.Builder<MqttSubscription> subscriptionsBuilder;
-    private @Nullable Mqtt3SubscriptionViewBuilder.Default firstSubscriptionBuilder;
+    private final ImmutableList.@NotNull Builder<MqttSubscription> subscriptionsBuilder;
+    private Mqtt3SubscriptionViewBuilder.@Nullable Default firstSubscriptionBuilder;
 
     protected Mqtt3SubscribeViewBuilder() {
         subscriptionsBuilder = ImmutableList.builder();
@@ -58,7 +58,7 @@ public abstract class Mqtt3SubscribeViewBuilder<B extends Mqtt3SubscribeViewBuil
         return self();
     }
 
-    public @NotNull Mqtt3SubscriptionViewBuilder.Nested<B> addSubscription() {
+    public Mqtt3SubscriptionViewBuilder.@NotNull Nested<B> addSubscription() {
         return new Mqtt3SubscriptionViewBuilder.Nested<>(this::addSubscription);
     }
 
@@ -92,7 +92,7 @@ public abstract class Mqtt3SubscribeViewBuilder<B extends Mqtt3SubscribeViewBuil
         return self();
     }
 
-    private @NotNull Mqtt3SubscriptionViewBuilder.Default getFirstSubscriptionBuilder() {
+    private Mqtt3SubscriptionViewBuilder.@NotNull Default getFirstSubscriptionBuilder() {
         if (firstSubscriptionBuilder == null) {
             firstSubscriptionBuilder = new Mqtt3SubscriptionViewBuilder.Default();
         }
@@ -116,7 +116,7 @@ public abstract class Mqtt3SubscribeViewBuilder<B extends Mqtt3SubscribeViewBuil
         return self();
     }
 
-    public @NotNull MqttTopicFilterImplBuilder.Nested<B> topicFilter() {
+    public MqttTopicFilterImplBuilder.@NotNull Nested<B> topicFilter() {
         return new MqttTopicFilterImplBuilder.Nested<>(this::topicFilter);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/mqtt3/Mqtt3SubscriptionView.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/mqtt3/Mqtt3SubscriptionView.java
@@ -67,7 +67,7 @@ public class Mqtt3SubscriptionView implements Mqtt3Subscription {
     }
 
     @Override
-    public @NotNull Mqtt3SubscriptionViewBuilder.Default extend() {
+    public Mqtt3SubscriptionViewBuilder.@NotNull Default extend() {
         return new Mqtt3SubscriptionViewBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/mqtt3/Mqtt3SubscriptionViewBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/subscribe/mqtt3/Mqtt3SubscriptionViewBuilder.java
@@ -58,7 +58,7 @@ public abstract class Mqtt3SubscriptionViewBuilder<B extends Mqtt3SubscriptionVi
         return self();
     }
 
-    public @NotNull MqttTopicFilterImplBuilder.Nested<B> topicFilter() {
+    public MqttTopicFilterImplBuilder.@NotNull Nested<B> topicFilter() {
         return new MqttTopicFilterImplBuilder.Nested<>(this::topicFilter);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/unsubscribe/MqttUnsubscribe.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/unsubscribe/MqttUnsubscribe.java
@@ -48,7 +48,7 @@ public class MqttUnsubscribe extends MqttMessageWithUserProperties implements Mq
     }
 
     @Override
-    public @NotNull MqttUnsubscribeBuilder.Default extend() {
+    public MqttUnsubscribeBuilder.@NotNull Default extend() {
         return new MqttUnsubscribeBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/unsubscribe/MqttUnsubscribeBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/unsubscribe/MqttUnsubscribeBuilder.java
@@ -40,7 +40,7 @@ import java.util.stream.Stream;
  */
 public abstract class MqttUnsubscribeBuilder<B extends MqttUnsubscribeBuilder<B>> {
 
-    private final @NotNull ImmutableList.Builder<MqttTopicFilterImpl> topicFiltersBuilder;
+    private final ImmutableList.@NotNull Builder<MqttTopicFilterImpl> topicFiltersBuilder;
     private @NotNull MqttUserPropertiesImpl userProperties = MqttUserPropertiesImpl.NO_USER_PROPERTIES;
 
     MqttUnsubscribeBuilder() {
@@ -65,7 +65,7 @@ public abstract class MqttUnsubscribeBuilder<B extends MqttUnsubscribeBuilder<B>
         return self();
     }
 
-    public @NotNull MqttTopicFilterImplBuilder.Nested<B> addTopicFilter() {
+    public MqttTopicFilterImplBuilder.@NotNull Nested<B> addTopicFilter() {
         return new MqttTopicFilterImplBuilder.Nested<>(this::addTopicFilter);
     }
 
@@ -107,7 +107,7 @@ public abstract class MqttUnsubscribeBuilder<B extends MqttUnsubscribeBuilder<B>
         return self();
     }
 
-    public @NotNull MqttUserPropertiesImplBuilder.Nested<B> userProperties() {
+    public MqttUserPropertiesImplBuilder.@NotNull Nested<B> userProperties() {
         return new MqttUserPropertiesImplBuilder.Nested<>(userProperties, this::userProperties);
     }
 
@@ -119,7 +119,7 @@ public abstract class MqttUnsubscribeBuilder<B extends MqttUnsubscribeBuilder<B>
         return addTopicFilter(topicFilter);
     }
 
-    public @NotNull MqttTopicFilterImplBuilder.Nested<B> topicFilter() {
+    public MqttTopicFilterImplBuilder.@NotNull Nested<B> topicFilter() {
         return new MqttTopicFilterImplBuilder.Nested<>(this::topicFilter);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeView.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeView.java
@@ -59,7 +59,7 @@ public class Mqtt3UnsubscribeView implements Mqtt3Unsubscribe {
     }
 
     @Override
-    public @NotNull Mqtt3UnsubscribeViewBuilder.Default extend() {
+    public Mqtt3UnsubscribeViewBuilder.@NotNull Default extend() {
         return new Mqtt3UnsubscribeViewBuilder.Default(this);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeViewBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeViewBuilder.java
@@ -38,7 +38,7 @@ import java.util.stream.Stream;
  */
 public abstract class Mqtt3UnsubscribeViewBuilder<B extends Mqtt3UnsubscribeViewBuilder<B>> {
 
-    private final @NotNull ImmutableList.Builder<MqttTopicFilterImpl> topicFiltersBuilder;
+    private final ImmutableList.@NotNull Builder<MqttTopicFilterImpl> topicFiltersBuilder;
 
     Mqtt3UnsubscribeViewBuilder() {
         topicFiltersBuilder = ImmutableList.builder();
@@ -62,7 +62,7 @@ public abstract class Mqtt3UnsubscribeViewBuilder<B extends Mqtt3UnsubscribeView
         return self();
     }
 
-    public @NotNull MqttTopicFilterImplBuilder.Nested<B> addTopicFilter() {
+    public MqttTopicFilterImplBuilder.@NotNull Nested<B> addTopicFilter() {
         return new MqttTopicFilterImplBuilder.Nested<>(this::addTopicFilter);
     }
 
@@ -107,7 +107,7 @@ public abstract class Mqtt3UnsubscribeViewBuilder<B extends Mqtt3UnsubscribeView
         return addTopicFilter(topicFilter);
     }
 
-    public @NotNull MqttTopicFilterImplBuilder.Nested<B> topicFilter() {
+    public MqttTopicFilterImplBuilder.@NotNull Nested<B> topicFilter() {
         return new MqttTopicFilterImplBuilder.Nested<>(this::topicFilter);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3AsyncClientView.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3AsyncClientView.java
@@ -105,7 +105,7 @@ public class Mqtt3AsyncClientView implements Mqtt3AsyncClient {
     }
 
     @Override
-    public @NotNull Mqtt3ConnectViewBuilder.Send<CompletableFuture<Mqtt3ConnAck>> connectWith() {
+    public Mqtt3ConnectViewBuilder.@NotNull Send<CompletableFuture<Mqtt3ConnAck>> connectWith() {
         return new Mqtt3ConnectViewBuilder.Send<>(this::connect);
     }
 
@@ -221,7 +221,7 @@ public class Mqtt3AsyncClientView implements Mqtt3AsyncClient {
     }
 
     @Override
-    public @NotNull Mqtt3UnsubscribeViewBuilder.Send<CompletableFuture<Void>> unsubscribeWith() {
+    public Mqtt3UnsubscribeViewBuilder.@NotNull Send<CompletableFuture<Void>> unsubscribeWith() {
         return new Mqtt3UnsubscribeViewBuilder.Send<>(this::unsubscribe);
     }
 
@@ -241,7 +241,7 @@ public class Mqtt3AsyncClientView implements Mqtt3AsyncClient {
     }
 
     @Override
-    public @NotNull Mqtt3PublishViewBuilder.Send<CompletableFuture<Mqtt3Publish>> publishWith() {
+    public Mqtt3PublishViewBuilder.@NotNull Send<CompletableFuture<Mqtt3Publish>> publishWith() {
         return new Mqtt3PublishViewBuilder.Send<>(this::publish);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3BlockingClientView.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3BlockingClientView.java
@@ -81,7 +81,7 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
     }
 
     @Override
-    public @NotNull Mqtt3ConnectViewBuilder.Send<Mqtt3ConnAck> connectWith() {
+    public Mqtt3ConnectViewBuilder.@NotNull Send<Mqtt3ConnAck> connectWith() {
         return new Mqtt3ConnectViewBuilder.Send<>(this::connect);
     }
 
@@ -96,7 +96,7 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
     }
 
     @Override
-    public @NotNull Mqtt3SubscribeViewBuilder.Send<Mqtt3SubAck> subscribeWith() {
+    public Mqtt3SubscribeViewBuilder.@NotNull Send<Mqtt3SubAck> subscribeWith() {
         return new Mqtt3SubscribeViewBuilder.Send<>(this::subscribe);
     }
 
@@ -125,7 +125,7 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
     }
 
     @Override
-    public @NotNull Mqtt3UnsubscribeViewBuilder.SendVoid unsubscribeWith() {
+    public Mqtt3UnsubscribeViewBuilder.@NotNull SendVoid unsubscribeWith() {
         return new Mqtt3UnsubscribeViewBuilder.SendVoid(this::unsubscribe);
     }
 
@@ -140,7 +140,7 @@ public class Mqtt3BlockingClientView implements Mqtt3BlockingClient {
     }
 
     @Override
-    public @NotNull Mqtt3PublishViewBuilder.SendVoid publishWith() {
+    public Mqtt3PublishViewBuilder.@NotNull SendVoid publishWith() {
         return new Mqtt3PublishViewBuilder.SendVoid(this::publish);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3RxClientView.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3RxClientView.java
@@ -100,7 +100,7 @@ public class Mqtt3RxClientView implements Mqtt3RxClient {
     }
 
     @Override
-    public @NotNull Mqtt3ConnectViewBuilder.Nested<Single<Mqtt3ConnAck>> connectWith() {
+    public Mqtt3ConnectViewBuilder.@NotNull Nested<Single<Mqtt3ConnAck>> connectWith() {
         return new Mqtt3ConnectViewBuilder.Nested<>(this::connect);
     }
 
@@ -114,7 +114,7 @@ public class Mqtt3RxClientView implements Mqtt3RxClient {
     }
 
     @Override
-    public @NotNull Mqtt3SubscribeViewBuilder.Nested<Single<Mqtt3SubAck>> subscribeWith() {
+    public Mqtt3SubscribeViewBuilder.@NotNull Nested<Single<Mqtt3SubAck>> subscribeWith() {
         return new Mqtt3SubscribeViewBuilder.Nested<>(this::subscribe);
     }
 
@@ -126,7 +126,7 @@ public class Mqtt3RxClientView implements Mqtt3RxClient {
     }
 
     @Override
-    public @NotNull Mqtt3SubscribeViewBuilder.Nested<FlowableWithSingle<Mqtt3Publish, Mqtt3SubAck>> subscribeStreamWith() {
+    public Mqtt3SubscribeViewBuilder.@NotNull Nested<FlowableWithSingle<Mqtt3Publish, Mqtt3SubAck>> subscribeStreamWith() {
         return new Mqtt3SubscribeViewBuilder.Nested<>(this::subscribeStream);
     }
 
@@ -177,7 +177,7 @@ public class Mqtt3RxClientView implements Mqtt3RxClient {
     }
 
     @Override
-    public @NotNull Mqtt3UnsubscribeViewBuilder.Nested<Completable> unsubscribeWith() {
+    public Mqtt3UnsubscribeViewBuilder.@NotNull Nested<Completable> unsubscribeWith() {
         return new Mqtt3UnsubscribeViewBuilder.Nested<>(this::unsubscribe);
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3RxClientViewBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/mqtt3/Mqtt3RxClientViewBuilder.java
@@ -55,7 +55,7 @@ public class Mqtt3RxClientViewBuilder extends MqttRxClientBuilderBase<Mqtt3RxCli
     }
 
     @Override
-    public @NotNull Mqtt3SimpleAuthViewBuilder.Nested<Mqtt3RxClientViewBuilder> simpleAuth() {
+    public Mqtt3SimpleAuthViewBuilder.@NotNull Nested<Mqtt3RxClientViewBuilder> simpleAuth() {
         return new Mqtt3SimpleAuthViewBuilder.Nested<>(this::simpleAuth);
     }
 
@@ -67,7 +67,7 @@ public class Mqtt3RxClientViewBuilder extends MqttRxClientBuilderBase<Mqtt3RxCli
     }
 
     @Override
-    public @NotNull Mqtt3PublishViewBuilder.WillNested<Mqtt3RxClientViewBuilder> willPublish() {
+    public Mqtt3PublishViewBuilder.@NotNull WillNested<Mqtt3RxClientViewBuilder> willPublish() {
         return new Mqtt3PublishViewBuilder.WillNested<>(this::willPublish);
     }
 

--- a/src/main/java/com/hivemq/client/mqtt/MqttClientBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttClientBuilderBase.java
@@ -147,7 +147,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @deprecated use {@link #sslConfig()}.
      */
     @Deprecated
-    default @NotNull MqttClientSslConfigBuilder.Nested<? extends B> useSsl() {
+    default MqttClientSslConfigBuilder.@NotNull Nested<? extends B> useSsl() {
         return sslConfig();
     }
 
@@ -162,7 +162,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @since 1.1
      */
     @CheckReturnValue
-    @NotNull MqttClientSslConfigBuilder.Nested<? extends B> sslConfig();
+    MqttClientSslConfigBuilder.@NotNull Nested<? extends B> sslConfig();
 
     /**
      * Use {@link #webSocketWithDefaultConfig()}.
@@ -215,7 +215,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @deprecated use {@link #webSocketConfig()}.
      */
     @Deprecated
-    default @NotNull MqttWebSocketConfigBuilder.Nested<? extends B> useWebSocket() {
+    default MqttWebSocketConfigBuilder.@NotNull Nested<? extends B> useWebSocket() {
         return webSocketConfig();
     }
 
@@ -230,7 +230,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @since 1.1
      */
     @CheckReturnValue
-    @NotNull MqttWebSocketConfigBuilder.Nested<? extends B> webSocketConfig();
+    MqttWebSocketConfigBuilder.@NotNull Nested<? extends B> webSocketConfig();
 
     /**
      * Sets the {@link MqttClientConfig#getTransportConfig() transport configuration}.
@@ -253,7 +253,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @since 1.1
      */
     @CheckReturnValue
-    @NotNull MqttClientTransportConfigBuilder.Nested<? extends B> transportConfig();
+    MqttClientTransportConfigBuilder.@NotNull Nested<? extends B> transportConfig();
 
     /**
      * Sets the {@link MqttClientConfig#getExecutorConfig() executor configuration}.
@@ -274,7 +274,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @see #executorConfig(MqttClientExecutorConfig)
      */
     @CheckReturnValue
-    @NotNull MqttClientExecutorConfigBuilder.Nested<? extends B> executorConfig();
+    MqttClientExecutorConfigBuilder.@NotNull Nested<? extends B> executorConfig();
 
     /**
      * Uses automatic reconnect with the default configuration.
@@ -307,7 +307,7 @@ public interface MqttClientBuilderBase<B extends MqttClientBuilderBase<B>> {
      * @since 1.1
      */
     @CheckReturnValue
-    @NotNull MqttClientAutoReconnectBuilder.Nested<? extends B> automaticReconnect();
+    MqttClientAutoReconnectBuilder.@NotNull Nested<? extends B> automaticReconnect();
 
     /**
      * Adds a listener which is notified when the client is connected (a successful ConnAck message is received).

--- a/src/main/java/com/hivemq/client/mqtt/MqttClientTransportConfigBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/MqttClientTransportConfigBuilderBase.java
@@ -146,7 +146,7 @@ public interface MqttClientTransportConfigBuilderBase<B extends MqttClientTransp
      * @see #sslConfig(MqttClientSslConfig)
      */
     @CheckReturnValue
-    @NotNull MqttClientSslConfigBuilder.Nested<? extends B> sslConfig();
+    MqttClientSslConfigBuilder.@NotNull Nested<? extends B> sslConfig();
 
     /**
      * Sets the {@link MqttClientTransportConfig#getWebSocketConfig() WebSocket transport configuration} to the default
@@ -177,7 +177,7 @@ public interface MqttClientTransportConfigBuilderBase<B extends MqttClientTransp
      * @see #webSocketConfig(MqttWebSocketConfig)
      */
     @CheckReturnValue
-    @NotNull MqttWebSocketConfigBuilder.Nested<? extends B> webSocketConfig();
+    MqttWebSocketConfigBuilder.@NotNull Nested<? extends B> webSocketConfig();
 
     /**
      * Sets the optional {@link MqttClientTransportConfig#getProxyConfig() proxy configuration}.
@@ -201,7 +201,7 @@ public interface MqttClientTransportConfigBuilderBase<B extends MqttClientTransp
      * @since 1.2
      */
     @CheckReturnValue
-    @NotNull MqttProxyConfigBuilder.Nested<? extends B> proxyConfig();
+    MqttProxyConfigBuilder.@NotNull Nested<? extends B> proxyConfig();
 
     /**
      * Sets the {@link MqttClientTransportConfig#getSocketConnectTimeoutMs() timeout for connecting the socket to the

--- a/src/main/java/com/hivemq/client/mqtt/datatypes/MqttSharedTopicFilter.java
+++ b/src/main/java/com/hivemq/client/mqtt/datatypes/MqttSharedTopicFilter.java
@@ -85,5 +85,5 @@ public interface MqttSharedTopicFilter extends MqttTopicFilter {
      *
      * @return the created builder.
      */
-    @NotNull MqttSharedTopicFilterBuilder.Complete extendShared();
+    MqttSharedTopicFilterBuilder.@NotNull Complete extendShared();
 }

--- a/src/main/java/com/hivemq/client/mqtt/datatypes/MqttTopic.java
+++ b/src/main/java/com/hivemq/client/mqtt/datatypes/MqttTopic.java
@@ -80,5 +80,5 @@ public interface MqttTopic extends MqttUtf8String {
      *
      * @return the created builder.
      */
-    @NotNull MqttTopicBuilder.Complete extend();
+    MqttTopicBuilder.@NotNull Complete extend();
 }

--- a/src/main/java/com/hivemq/client/mqtt/datatypes/MqttTopicFilter.java
+++ b/src/main/java/com/hivemq/client/mqtt/datatypes/MqttTopicFilter.java
@@ -121,5 +121,5 @@ public interface MqttTopicFilter extends MqttUtf8String {
      *
      * @return the created builder.
      */
-    @NotNull MqttTopicFilterBuilder.Complete extend();
+    MqttTopicFilterBuilder.@NotNull Complete extend();
 }

--- a/src/main/java/com/hivemq/client/mqtt/lifecycle/MqttClientReconnector.java
+++ b/src/main/java/com/hivemq/client/mqtt/lifecycle/MqttClientReconnector.java
@@ -204,7 +204,7 @@ public interface MqttClientReconnector {
      * @see #transportConfig(MqttClientTransportConfig)
      */
     @CheckReturnValue
-    @NotNull MqttClientTransportConfigBuilder.Nested<? extends MqttClientReconnector> transportConfig();
+    MqttClientTransportConfigBuilder.@NotNull Nested<? extends MqttClientReconnector> transportConfig();
 
     /**
      * Returns the currently set transport configuration the client will try to reconnect with.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3AsyncClient.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3AsyncClient.java
@@ -78,7 +78,7 @@ public interface Mqtt3AsyncClient extends Mqtt3Client {
      * @see #connect(Mqtt3Connect)
      */
     @CheckReturnValue
-    @NotNull Mqtt3ConnectBuilder.Send<CompletableFuture<Mqtt3ConnAck>> connectWith();
+    Mqtt3ConnectBuilder.@NotNull Send<CompletableFuture<Mqtt3ConnAck>> connectWith();
 
     /**
      * Subscribes this client with the given Subscribe message.
@@ -197,7 +197,7 @@ public interface Mqtt3AsyncClient extends Mqtt3Client {
      * @see #subscribe(Mqtt3Subscribe, Consumer, Executor, boolean)
      */
     @CheckReturnValue
-    @NotNull Mqtt3SubscribeAndCallbackBuilder.Start subscribeWith();
+    Mqtt3SubscribeAndCallbackBuilder.@NotNull Start subscribeWith();
 
     /**
      * Globally consumes all incoming Publish messages matching the given filter.
@@ -282,7 +282,7 @@ public interface Mqtt3AsyncClient extends Mqtt3Client {
      * @see #unsubscribe(Mqtt3Unsubscribe)
      */
     @CheckReturnValue
-    @NotNull Mqtt3UnsubscribeBuilder.Send.Start<CompletableFuture<Void>> unsubscribeWith();
+    Mqtt3UnsubscribeBuilder.Send.@NotNull Start<CompletableFuture<Void>> unsubscribeWith();
 
     /**
      * Publishes the given Publish message.
@@ -308,7 +308,7 @@ public interface Mqtt3AsyncClient extends Mqtt3Client {
      * @see #publish(Mqtt3Publish)
      */
     @CheckReturnValue
-    @NotNull Mqtt3PublishBuilder.Send<CompletableFuture<Mqtt3Publish>> publishWith();
+    Mqtt3PublishBuilder.@NotNull Send<CompletableFuture<Mqtt3Publish>> publishWith();
 
     /**
      * Disconnects this client.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3BlockingClient.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3BlockingClient.java
@@ -71,7 +71,7 @@ public interface Mqtt3BlockingClient extends Mqtt3Client {
      * @see #connect(Mqtt3Connect)
      */
     @CheckReturnValue
-    @NotNull Mqtt3ConnectBuilder.Send<Mqtt3ConnAck> connectWith();
+    Mqtt3ConnectBuilder.@NotNull Send<Mqtt3ConnAck> connectWith();
 
     /**
      * Subscribes this client with the given Subscribe message.
@@ -96,7 +96,7 @@ public interface Mqtt3BlockingClient extends Mqtt3Client {
      * @see #subscribe(Mqtt3Subscribe)
      */
     @CheckReturnValue
-    @NotNull Mqtt3SubscribeBuilder.Send.Start<Mqtt3SubAck> subscribeWith();
+    Mqtt3SubscribeBuilder.Send.@NotNull Start<Mqtt3SubAck> subscribeWith();
 
     /**
      * Globally consumes all incoming Publish messages matching the given filter.
@@ -137,7 +137,7 @@ public interface Mqtt3BlockingClient extends Mqtt3Client {
      * @see #unsubscribe(Mqtt3Unsubscribe)
      */
     @CheckReturnValue
-    @NotNull Mqtt3UnsubscribeBuilder.SendVoid.Start unsubscribeWith();
+    Mqtt3UnsubscribeBuilder.SendVoid.@NotNull Start unsubscribeWith();
 
     /**
      * Publishes the given Publish message.
@@ -156,7 +156,7 @@ public interface Mqtt3BlockingClient extends Mqtt3Client {
      * @see #publish(Mqtt3Publish)
      */
     @CheckReturnValue
-    @NotNull Mqtt3PublishBuilder.SendVoid publishWith();
+    Mqtt3PublishBuilder.@NotNull SendVoid publishWith();
 
     /**
      * Disconnects this client with the given Disconnect message.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3ClientBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3ClientBuilder.java
@@ -59,7 +59,7 @@ public interface Mqtt3ClientBuilder extends MqttClientBuilderBase<Mqtt3ClientBui
      * @since 1.1
      */
     @CheckReturnValue
-    @NotNull Mqtt3SimpleAuthBuilder.Nested<? extends Mqtt3ClientBuilder> simpleAuth();
+    Mqtt3SimpleAuthBuilder.@NotNull Nested<? extends Mqtt3ClientBuilder> simpleAuth();
 
     /**
      * Sets the optional {@link Mqtt3ClientConfig#getWillPublish() Will Publish}.
@@ -83,7 +83,7 @@ public interface Mqtt3ClientBuilder extends MqttClientBuilderBase<Mqtt3ClientBui
      * @since 1.1
      */
     @CheckReturnValue
-    @NotNull Mqtt3WillPublishBuilder.Nested<? extends Mqtt3ClientBuilder> willPublish();
+    Mqtt3WillPublishBuilder.@NotNull Nested<? extends Mqtt3ClientBuilder> willPublish();
 
     /**
      * Builds the {@link Mqtt3Client}.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3RxClient.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/Mqtt3RxClient.java
@@ -83,7 +83,7 @@ public interface Mqtt3RxClient extends Mqtt3Client {
      * @see #connect(Mqtt3Connect)
      */
     @CheckReturnValue
-    @NotNull Mqtt3ConnectBuilder.Nested<Single<Mqtt3ConnAck>> connectWith();
+    Mqtt3ConnectBuilder.@NotNull Nested<Single<Mqtt3ConnAck>> connectWith();
 
     /**
      * Creates a {@link Single} for subscribing this client with the given Subscribe message.
@@ -121,7 +121,7 @@ public interface Mqtt3RxClient extends Mqtt3Client {
      * @see #subscribe(Mqtt3Subscribe)
      */
     @CheckReturnValue
-    @NotNull Mqtt3SubscribeBuilder.Nested.Start<Single<Mqtt3SubAck>> subscribeWith();
+    Mqtt3SubscribeBuilder.Nested.@NotNull Start<Single<Mqtt3SubAck>> subscribeWith();
 
     /**
      * Use {@link #subscribePublishes(Mqtt3Subscribe)}.
@@ -140,7 +140,7 @@ public interface Mqtt3RxClient extends Mqtt3Client {
      * @deprecated use {@link #subscribePublishesWith()}.
      */
     @Deprecated
-    @NotNull Mqtt3SubscribeBuilder.Nested.Start<FlowableWithSingle<Mqtt3Publish, Mqtt3SubAck>> subscribeStreamWith();
+    Mqtt3SubscribeBuilder.Nested.@NotNull Start<FlowableWithSingle<Mqtt3Publish, Mqtt3SubAck>> subscribeStreamWith();
 
     /**
      * Creates a {@link FlowableWithSingle} for subscribing this client with the given Subscribe message.
@@ -214,7 +214,7 @@ public interface Mqtt3RxClient extends Mqtt3Client {
      * @since 1.2
      */
     @CheckReturnValue
-    @NotNull Mqtt3SubscribeBuilder.Publishes.Start<FlowableWithSingle<Mqtt3Publish, Mqtt3SubAck>> subscribePublishesWith();
+    Mqtt3SubscribeBuilder.Publishes.@NotNull Start<FlowableWithSingle<Mqtt3Publish, Mqtt3SubAck>> subscribePublishesWith();
 
     /**
      * Creates a {@link Flowable} for globally consuming all incoming Publish messages matching the given filter.
@@ -287,7 +287,7 @@ public interface Mqtt3RxClient extends Mqtt3Client {
      * @see #unsubscribe(Mqtt3Unsubscribe)
      */
     @CheckReturnValue
-    @NotNull Mqtt3UnsubscribeBuilder.Nested.Start<Completable> unsubscribeWith();
+    Mqtt3UnsubscribeBuilder.Nested.@NotNull Start<Completable> unsubscribeWith();
 
     /**
      * Creates a {@link Flowable} for publishing the Publish messages emitted by the given {@link Flowable}.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/lifecycle/Mqtt3ClientReconnector.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/lifecycle/Mqtt3ClientReconnector.java
@@ -61,7 +61,7 @@ public interface Mqtt3ClientReconnector extends MqttClientReconnector {
 
     @Override
     @CheckReturnValue
-    @NotNull MqttClientTransportConfigBuilder.Nested<? extends Mqtt3ClientReconnector> transportConfig();
+    MqttClientTransportConfigBuilder.@NotNull Nested<? extends Mqtt3ClientReconnector> transportConfig();
 
     /**
      * Sets a different Connect message the client will try to reconnect with.
@@ -81,7 +81,7 @@ public interface Mqtt3ClientReconnector extends MqttClientReconnector {
      * @see #connect(Mqtt3Connect)
      */
     @CheckReturnValue
-    @NotNull Mqtt3ConnectBuilder.Nested<? extends Mqtt3ClientReconnector> connectWith();
+    Mqtt3ConnectBuilder.@NotNull Nested<? extends Mqtt3ClientReconnector> connectWith();
 
     /**
      * Returns the currently set Connect message the client will try to reconnect with.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilderBase.java
@@ -84,7 +84,7 @@ public interface Mqtt3ConnectBuilderBase<B extends Mqtt3ConnectBuilderBase<B>> {
      * @see #simpleAuth(Mqtt3SimpleAuth)
      */
     @CheckReturnValue
-    @NotNull Mqtt3SimpleAuthBuilder.Nested<? extends B> simpleAuth();
+    Mqtt3SimpleAuthBuilder.@NotNull Nested<? extends B> simpleAuth();
 
     /**
      * Sets the optional {@link Mqtt3Connect#getWillPublish() Will Publish}.
@@ -106,5 +106,5 @@ public interface Mqtt3ConnectBuilderBase<B extends Mqtt3ConnectBuilderBase<B>> {
      * @see #willPublish(Mqtt3Publish)
      */
     @CheckReturnValue
-    @NotNull Mqtt3WillPublishBuilder.Nested<? extends B> willPublish();
+    Mqtt3WillPublishBuilder.@NotNull Nested<? extends B> willPublish();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/publish/Mqtt3Publish.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/publish/Mqtt3Publish.java
@@ -96,5 +96,5 @@ public interface Mqtt3Publish extends Mqtt3Message {
      *
      * @return the created builder.
      */
-    @NotNull Mqtt3PublishBuilder.Complete extend();
+    Mqtt3PublishBuilder.@NotNull Complete extend();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/publish/Mqtt3PublishBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/publish/Mqtt3PublishBuilderBase.java
@@ -64,7 +64,7 @@ public interface Mqtt3PublishBuilderBase<C extends Mqtt3PublishBuilderBase.Compl
      * @see #topic(MqttTopic)
      */
     @CheckReturnValue
-    @NotNull MqttTopicBuilder.Nested<? extends C> topic();
+    MqttTopicBuilder.@NotNull Nested<? extends C> topic();
 
     /**
      * {@link Mqtt3PublishBuilderBase} that is complete which means all mandatory fields are set.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3Subscribe.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3Subscribe.java
@@ -39,7 +39,7 @@ public interface Mqtt3Subscribe extends Mqtt3Message {
      *
      * @return the created builder.
      */
-    static @NotNull Mqtt3SubscribeBuilder.Start builder() {
+    static Mqtt3SubscribeBuilder.@NotNull Start builder() {
         return new Mqtt3SubscribeViewBuilder.Default();
     }
 
@@ -59,5 +59,5 @@ public interface Mqtt3Subscribe extends Mqtt3Message {
      *
      * @return the created builder.
      */
-    @NotNull Mqtt3SubscribeBuilder.Complete extend();
+    Mqtt3SubscribeBuilder.@NotNull Complete extend();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeBuilderBase.java
@@ -54,7 +54,7 @@ public interface Mqtt3SubscribeBuilderBase<C extends Mqtt3SubscribeBuilderBase<C
      * @see #addSubscription(Mqtt3Subscription)
      */
     @CheckReturnValue
-    @NotNull Mqtt3SubscriptionBuilder.Nested<? extends C> addSubscription();
+    Mqtt3SubscriptionBuilder.@NotNull Nested<? extends C> addSubscription();
 
     /**
      * Adds {@link Mqtt3Subscription}s to the {@link Mqtt3Subscribe#getSubscriptions() list of subscriptions}. At least

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilderBase.java
@@ -62,7 +62,7 @@ public interface Mqtt3SubscriptionBuilderBase<C extends Mqtt3SubscriptionBuilder
      * @see #topicFilter(MqttTopicFilter)
      */
     @CheckReturnValue
-    @NotNull MqttTopicFilterBuilder.Nested<? extends C> topicFilter();
+    MqttTopicFilterBuilder.@NotNull Nested<? extends C> topicFilter();
 
     /**
      * {@link Mqtt3SubscriptionBuilderBase} that is complete which means all mandatory fields are set.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/unsubscribe/Mqtt3Unsubscribe.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/unsubscribe/Mqtt3Unsubscribe.java
@@ -41,7 +41,7 @@ public interface Mqtt3Unsubscribe extends Mqtt3Message {
      *
      * @return the created builder.
      */
-    static @NotNull Mqtt3UnsubscribeBuilder.Start builder() {
+    static Mqtt3UnsubscribeBuilder.@NotNull Start builder() {
         return new Mqtt3UnsubscribeViewBuilder.Default();
     }
 
@@ -60,5 +60,5 @@ public interface Mqtt3Unsubscribe extends Mqtt3Message {
      *
      * @return the created builder.
      */
-    @NotNull Mqtt3UnsubscribeBuilder.Complete extend();
+    Mqtt3UnsubscribeBuilder.@NotNull Complete extend();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilderBase.java
@@ -67,7 +67,7 @@ public interface Mqtt3UnsubscribeBuilderBase<C extends Mqtt3UnsubscribeBuilderBa
      * @see #addTopicFilter(MqttTopicFilter)
      */
     @CheckReturnValue
-    @NotNull MqttTopicFilterBuilder.Nested<? extends C> addTopicFilter();
+    MqttTopicFilterBuilder.@NotNull Nested<? extends C> addTopicFilter();
 
     /**
      * Adds {@link MqttTopicFilter Topic Filters} to the {@link Mqtt3Unsubscribe#getTopicFilters() list of Topic
@@ -148,6 +148,6 @@ public interface Mqtt3UnsubscribeBuilderBase<C extends Mqtt3UnsubscribeBuilderBa
          * @see #addTopicFilter(MqttTopicFilter)
          */
         @CheckReturnValue
-        @NotNull MqttTopicFilterBuilder.Nested<? extends C> topicFilter();
+        MqttTopicFilterBuilder.@NotNull Nested<? extends C> topicFilter();
     }
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5AsyncClient.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5AsyncClient.java
@@ -82,7 +82,7 @@ public interface Mqtt5AsyncClient extends Mqtt5Client {
      * @see #connect(Mqtt5Connect)
      */
     @CheckReturnValue
-    @NotNull Mqtt5ConnectBuilder.Send<CompletableFuture<Mqtt5ConnAck>> connectWith();
+    Mqtt5ConnectBuilder.@NotNull Send<CompletableFuture<Mqtt5ConnAck>> connectWith();
 
     /**
      * Subscribes this client with the given Subscribe message.
@@ -201,7 +201,7 @@ public interface Mqtt5AsyncClient extends Mqtt5Client {
      * @see #subscribe(Mqtt5Subscribe, Consumer, Executor, boolean)
      */
     @CheckReturnValue
-    @NotNull Mqtt5SubscribeAndCallbackBuilder.Start subscribeWith();
+    Mqtt5SubscribeAndCallbackBuilder.@NotNull Start subscribeWith();
 
     /**
      * Globally consumes all incoming Publish messages matching the given filter.
@@ -290,7 +290,7 @@ public interface Mqtt5AsyncClient extends Mqtt5Client {
      * @see #unsubscribe(Mqtt5Unsubscribe)
      */
     @CheckReturnValue
-    @NotNull Mqtt5UnsubscribeBuilder.Send.Start<CompletableFuture<Mqtt5UnsubAck>> unsubscribeWith();
+    Mqtt5UnsubscribeBuilder.Send.@NotNull Start<CompletableFuture<Mqtt5UnsubAck>> unsubscribeWith();
 
     /**
      * Publishes the given Publish message.
@@ -320,7 +320,7 @@ public interface Mqtt5AsyncClient extends Mqtt5Client {
      * @see #publish(Mqtt5Publish)
      */
     @CheckReturnValue
-    @NotNull Mqtt5PublishBuilder.Send<CompletableFuture<Mqtt5PublishResult>> publishWith();
+    Mqtt5PublishBuilder.@NotNull Send<CompletableFuture<Mqtt5PublishResult>> publishWith();
 
     /**
      * Re-authenticates this client.
@@ -366,7 +366,7 @@ public interface Mqtt5AsyncClient extends Mqtt5Client {
      * @see #disconnect(Mqtt5Disconnect)
      */
     @CheckReturnValue
-    @NotNull Mqtt5DisconnectBuilder.Send<CompletableFuture<Void>> disconnectWith();
+    Mqtt5DisconnectBuilder.@NotNull Send<CompletableFuture<Void>> disconnectWith();
 
     @Override
     @CheckReturnValue

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5BlockingClient.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5BlockingClient.java
@@ -75,7 +75,7 @@ public interface Mqtt5BlockingClient extends Mqtt5Client {
      * @see #connect(Mqtt5Connect)
      */
     @CheckReturnValue
-    @NotNull Mqtt5ConnectBuilder.Send<Mqtt5ConnAck> connectWith();
+    Mqtt5ConnectBuilder.@NotNull Send<Mqtt5ConnAck> connectWith();
 
     /**
      * Subscribes this client with the given Subscribe message.
@@ -100,7 +100,7 @@ public interface Mqtt5BlockingClient extends Mqtt5Client {
      * @see #subscribe(Mqtt5Subscribe)
      */
     @CheckReturnValue
-    @NotNull Mqtt5SubscribeBuilder.Send.Start<Mqtt5SubAck> subscribeWith();
+    Mqtt5SubscribeBuilder.Send.@NotNull Start<Mqtt5SubAck> subscribeWith();
 
     /**
      * Globally consumes all incoming Publish messages matching the given filter.
@@ -145,7 +145,7 @@ public interface Mqtt5BlockingClient extends Mqtt5Client {
      * @see #unsubscribe(Mqtt5Unsubscribe)
      */
     @CheckReturnValue
-    @NotNull Mqtt5UnsubscribeBuilder.Send.Start<Mqtt5UnsubAck> unsubscribeWith();
+    Mqtt5UnsubscribeBuilder.Send.@NotNull Start<Mqtt5UnsubAck> unsubscribeWith();
 
     /**
      * Publishes the given Publish message.
@@ -170,7 +170,7 @@ public interface Mqtt5BlockingClient extends Mqtt5Client {
      * @see #publish(Mqtt5Publish)
      */
     @CheckReturnValue
-    @NotNull Mqtt5PublishBuilder.Send<Mqtt5PublishResult> publishWith();
+    Mqtt5PublishBuilder.@NotNull Send<Mqtt5PublishResult> publishWith();
 
     /**
      * Re-authenticates this client.
@@ -204,7 +204,7 @@ public interface Mqtt5BlockingClient extends Mqtt5Client {
      * @see #disconnect(Mqtt5Disconnect)
      */
     @CheckReturnValue
-    @NotNull Mqtt5DisconnectBuilder.SendVoid disconnectWith();
+    Mqtt5DisconnectBuilder.@NotNull SendVoid disconnectWith();
 
     @Override
     @CheckReturnValue

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5ClientBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5ClientBuilder.java
@@ -57,7 +57,7 @@ public interface Mqtt5ClientBuilder extends MqttClientBuilderBase<Mqtt5ClientBui
      * @see #advancedConfig(Mqtt5ClientAdvancedConfig)
      */
     @CheckReturnValue
-    @NotNull Mqtt5ClientAdvancedConfigBuilder.Nested<? extends Mqtt5ClientBuilder> advancedConfig();
+    Mqtt5ClientAdvancedConfigBuilder.@NotNull Nested<? extends Mqtt5ClientBuilder> advancedConfig();
 
     /**
      * Sets the optional {@link Mqtt5ClientConfig#getSimpleAuth() simple authentication and/or authorization related
@@ -83,7 +83,7 @@ public interface Mqtt5ClientBuilder extends MqttClientBuilderBase<Mqtt5ClientBui
      * @since 1.1
      */
     @CheckReturnValue
-    @NotNull Mqtt5SimpleAuthBuilder.Nested<? extends Mqtt5ClientBuilder> simpleAuth();
+    Mqtt5SimpleAuthBuilder.@NotNull Nested<? extends Mqtt5ClientBuilder> simpleAuth();
 
     /**
      * Sets the {@link Mqtt5ClientConfig#getEnhancedAuthMechanism() enhanced authentication and/or authorization
@@ -119,7 +119,7 @@ public interface Mqtt5ClientBuilder extends MqttClientBuilderBase<Mqtt5ClientBui
      * @since 1.1
      */
     @CheckReturnValue
-    @NotNull Mqtt5WillPublishBuilder.Nested<? extends Mqtt5ClientBuilder> willPublish();
+    Mqtt5WillPublishBuilder.@NotNull Nested<? extends Mqtt5ClientBuilder> willPublish();
 
     /**
      * Builds the {@link Mqtt5Client}.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5RxClient.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/Mqtt5RxClient.java
@@ -86,7 +86,7 @@ public interface Mqtt5RxClient extends Mqtt5Client {
      * @see #connect(Mqtt5Connect)
      */
     @CheckReturnValue
-    @NotNull Mqtt5ConnectBuilder.Nested<Single<Mqtt5ConnAck>> connectWith();
+    Mqtt5ConnectBuilder.@NotNull Nested<Single<Mqtt5ConnAck>> connectWith();
 
     /**
      * Creates a {@link Single} for subscribing this client with the given Subscribe message.
@@ -124,7 +124,7 @@ public interface Mqtt5RxClient extends Mqtt5Client {
      * @see #subscribe(Mqtt5Subscribe)
      */
     @CheckReturnValue
-    @NotNull Mqtt5SubscribeBuilder.Nested.Start<Single<Mqtt5SubAck>> subscribeWith();
+    Mqtt5SubscribeBuilder.Nested.@NotNull Start<Single<Mqtt5SubAck>> subscribeWith();
 
     /**
      * Use {@link #subscribePublishes(Mqtt5Subscribe)}.
@@ -143,7 +143,7 @@ public interface Mqtt5RxClient extends Mqtt5Client {
      * @deprecated use {@link #subscribePublishesWith()}.
      */
     @Deprecated
-    @NotNull Mqtt5SubscribeBuilder.Nested.Start<FlowableWithSingle<Mqtt5Publish, Mqtt5SubAck>> subscribeStreamWith();
+    Mqtt5SubscribeBuilder.Nested.@NotNull Start<FlowableWithSingle<Mqtt5Publish, Mqtt5SubAck>> subscribeStreamWith();
 
     /**
      * Creates a {@link FlowableWithSingle} for subscribing this client with the given Subscribe message.
@@ -217,7 +217,7 @@ public interface Mqtt5RxClient extends Mqtt5Client {
      * @since 1.2
      */
     @CheckReturnValue
-    @NotNull Mqtt5SubscribeBuilder.Publishes.Start<FlowableWithSingle<Mqtt5Publish, Mqtt5SubAck>> subscribePublishesWith();
+    Mqtt5SubscribeBuilder.Publishes.@NotNull Start<FlowableWithSingle<Mqtt5Publish, Mqtt5SubAck>> subscribePublishesWith();
 
     /**
      * Creates a {@link Flowable} for globally consuming all incoming Publish messages matching the given filter.
@@ -294,7 +294,7 @@ public interface Mqtt5RxClient extends Mqtt5Client {
      * @see #unsubscribe(Mqtt5Unsubscribe)
      */
     @CheckReturnValue
-    @NotNull Mqtt5UnsubscribeBuilder.Nested.Start<Single<Mqtt5UnsubAck>> unsubscribeWith();
+    Mqtt5UnsubscribeBuilder.Nested.@NotNull Start<Single<Mqtt5UnsubAck>> unsubscribeWith();
 
     /**
      * Creates a {@link Flowable} for publishing the Publish messages emitted by the given {@link Flowable}.
@@ -370,7 +370,7 @@ public interface Mqtt5RxClient extends Mqtt5Client {
      * @see #disconnect(Mqtt5Disconnect)
      */
     @CheckReturnValue
-    @NotNull Mqtt5DisconnectBuilder.Nested<Completable> disconnectWith();
+    Mqtt5DisconnectBuilder.@NotNull Nested<Completable> disconnectWith();
 
     @Override
     @CheckReturnValue

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/advanced/Mqtt5ClientAdvancedConfigBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/advanced/Mqtt5ClientAdvancedConfigBuilderBase.java
@@ -71,5 +71,5 @@ public interface Mqtt5ClientAdvancedConfigBuilderBase<B extends Mqtt5ClientAdvan
      * @see #interceptors(Mqtt5ClientInterceptors)
      */
     @CheckReturnValue
-    @NotNull Mqtt5ClientInterceptorsBuilder.Nested<? extends B> interceptors();
+    Mqtt5ClientInterceptorsBuilder.@NotNull Nested<? extends B> interceptors();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/lifecycle/Mqtt5ClientReconnector.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/lifecycle/Mqtt5ClientReconnector.java
@@ -61,7 +61,7 @@ public interface Mqtt5ClientReconnector extends MqttClientReconnector {
 
     @Override
     @CheckReturnValue
-    @NotNull MqttClientTransportConfigBuilder.Nested<? extends Mqtt5ClientReconnector> transportConfig();
+    MqttClientTransportConfigBuilder.@NotNull Nested<? extends Mqtt5ClientReconnector> transportConfig();
 
     /**
      * Sets a different Connect message the client will try to reconnect with.
@@ -81,7 +81,7 @@ public interface Mqtt5ClientReconnector extends MqttClientReconnector {
      * @see #connect(Mqtt5Connect)
      */
     @CheckReturnValue
-    @NotNull Mqtt5ConnectBuilder.Nested<? extends Mqtt5ClientReconnector> connectWith();
+    Mqtt5ConnectBuilder.@NotNull Nested<? extends Mqtt5ClientReconnector> connectWith();
 
     /**
      * Returns the currently set Connect message the client will try to reconnect with.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/auth/Mqtt5AuthBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/auth/Mqtt5AuthBuilder.java
@@ -75,5 +75,5 @@ public interface Mqtt5AuthBuilder extends Mqtt5EnhancedAuthBuilder {
      * @see #userProperties(Mqtt5UserProperties)
      */
     @CheckReturnValue
-    @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends Mqtt5AuthBuilder> userProperties();
+    Mqtt5UserPropertiesBuilder.@NotNull Nested<? extends Mqtt5AuthBuilder> userProperties();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilderBase.java
@@ -105,7 +105,7 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      * @see #restrictions(Mqtt5ConnectRestrictions)
      */
     @CheckReturnValue
-    @NotNull Mqtt5ConnectRestrictionsBuilder.Nested<? extends B> restrictions();
+    Mqtt5ConnectRestrictionsBuilder.@NotNull Nested<? extends B> restrictions();
 
     /**
      * Sets the optional {@link Mqtt5Connect#getSimpleAuth() simple authentication and/or authorization related data}.
@@ -128,7 +128,7 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      * @see #simpleAuth(Mqtt5SimpleAuth)
      */
     @CheckReturnValue
-    @NotNull Mqtt5SimpleAuthBuilder.Nested<? extends B> simpleAuth();
+    Mqtt5SimpleAuthBuilder.@NotNull Nested<? extends B> simpleAuth();
 
     /**
      * Sets the {@link Mqtt5Connect#getEnhancedAuthMechanism() enhanced authentication and/or authorization mechanism}.
@@ -160,7 +160,7 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      * @see #willPublish(Mqtt5Publish)
      */
     @CheckReturnValue
-    @NotNull Mqtt5WillPublishBuilder.Nested<? extends B> willPublish();
+    Mqtt5WillPublishBuilder.@NotNull Nested<? extends B> willPublish();
 
     /**
      * Sets the {@link Mqtt5Connect#getUserProperties() User Properties}.
@@ -181,5 +181,5 @@ public interface Mqtt5ConnectBuilderBase<B extends Mqtt5ConnectBuilderBase<B>> {
      * @see #userProperties(Mqtt5UserProperties)
      */
     @CheckReturnValue
-    @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends B> userProperties();
+    Mqtt5UserPropertiesBuilder.@NotNull Nested<? extends B> userProperties();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilderBase.java
@@ -118,5 +118,5 @@ public interface Mqtt5DisconnectBuilderBase<B extends Mqtt5DisconnectBuilderBase
      * @see #userProperties(Mqtt5UserProperties)
      */
     @CheckReturnValue
-    @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends B> userProperties();
+    Mqtt5UserPropertiesBuilder.@NotNull Nested<? extends B> userProperties();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5Publish.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5Publish.java
@@ -135,5 +135,5 @@ public interface Mqtt5Publish extends Mqtt5Message {
      *
      * @return the created builder.
      */
-    @NotNull Mqtt5PublishBuilder.Complete extend();
+    Mqtt5PublishBuilder.@NotNull Complete extend();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
@@ -50,7 +50,7 @@ public interface Mqtt5PublishBuilder extends Mqtt5PublishBuilderBase<Mqtt5Publis
          */
         @Override
         @CheckReturnValue
-        @NotNull Mqtt5WillPublishBuilder.Complete asWill();
+        Mqtt5WillPublishBuilder.@NotNull Complete asWill();
 
         /**
          * Builds the {@link Mqtt5Publish}.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5PublishBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5PublishBuilderBase.java
@@ -67,7 +67,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
      * @see #topic(MqttTopic)
      */
     @CheckReturnValue
-    @NotNull MqttTopicBuilder.Nested<? extends C> topic();
+    MqttTopicBuilder.@NotNull Nested<? extends C> topic();
 
     /**
      * {@link Mqtt5PublishBuilderBase} that is complete which means all mandatory fields are set.
@@ -188,7 +188,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          * @see #responseTopic(MqttTopic)
          */
         @CheckReturnValue
-        @NotNull MqttTopicBuilder.Nested<? extends C> responseTopic();
+        MqttTopicBuilder.@NotNull Nested<? extends C> responseTopic();
 
         /**
          * Sets the optional {@link Mqtt5Publish#getCorrelationData() correlation data}.
@@ -229,7 +229,7 @@ public interface Mqtt5PublishBuilderBase<C extends Mqtt5PublishBuilderBase.Compl
          * @see #userProperties(Mqtt5UserProperties)
          */
         @CheckReturnValue
-        @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends C> userProperties();
+        Mqtt5UserPropertiesBuilder.@NotNull Nested<? extends C> userProperties();
     }
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5WillPublish.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5WillPublish.java
@@ -54,5 +54,5 @@ public interface Mqtt5WillPublish extends Mqtt5Publish {
      *
      * @return the created builder.
      */
-    @NotNull Mqtt5WillPublishBuilder.Complete extendAsWill();
+    Mqtt5WillPublishBuilder.@NotNull Complete extendAsWill();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/puback/Mqtt5PubAckBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/puback/Mqtt5PubAckBuilder.java
@@ -75,5 +75,5 @@ public interface Mqtt5PubAckBuilder {
      * @see #userProperties(Mqtt5UserProperties)
      */
     @CheckReturnValue
-    @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends Mqtt5PubAckBuilder> userProperties();
+    Mqtt5UserPropertiesBuilder.@NotNull Nested<? extends Mqtt5PubAckBuilder> userProperties();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/pubcomp/Mqtt5PubCompBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/pubcomp/Mqtt5PubCompBuilder.java
@@ -67,7 +67,7 @@ public interface Mqtt5PubCompBuilder {
      * @see #userProperties(Mqtt5UserProperties)
      */
     @CheckReturnValue
-    @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends Mqtt5PubCompBuilder> userProperties();
+    Mqtt5UserPropertiesBuilder.@NotNull Nested<? extends Mqtt5PubCompBuilder> userProperties();
 
     /**
      * @return the Reason Code of the PubComp message.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/pubrec/Mqtt5PubRecBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/pubrec/Mqtt5PubRecBuilder.java
@@ -75,5 +75,5 @@ public interface Mqtt5PubRecBuilder {
      * @see #userProperties(Mqtt5UserProperties)
      */
     @CheckReturnValue
-    @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends Mqtt5PubRecBuilder> userProperties();
+    Mqtt5UserPropertiesBuilder.@NotNull Nested<? extends Mqtt5PubRecBuilder> userProperties();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/pubrel/Mqtt5PubRelBuilder.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/pubrel/Mqtt5PubRelBuilder.java
@@ -67,7 +67,7 @@ public interface Mqtt5PubRelBuilder {
      * @see #userProperties(Mqtt5UserProperties)
      */
     @CheckReturnValue
-    @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends Mqtt5PubRelBuilder> userProperties();
+    Mqtt5UserPropertiesBuilder.@NotNull Nested<? extends Mqtt5PubRelBuilder> userProperties();
 
     /**
      * @return the Reason Code of the PubRel message.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5Subscribe.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5Subscribe.java
@@ -40,7 +40,7 @@ public interface Mqtt5Subscribe extends Mqtt5Message {
      *
      * @return the created builder.
      */
-    static @NotNull Mqtt5SubscribeBuilder.Start builder() {
+    static Mqtt5SubscribeBuilder.@NotNull Start builder() {
         return new MqttSubscribeBuilder.Default();
     }
 
@@ -65,5 +65,5 @@ public interface Mqtt5Subscribe extends Mqtt5Message {
      *
      * @return the created builder.
      */
-    @NotNull Mqtt5SubscribeBuilder.Complete extend();
+    Mqtt5SubscribeBuilder.@NotNull Complete extend();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilderBase.java
@@ -56,7 +56,7 @@ public interface Mqtt5SubscribeBuilderBase<C extends Mqtt5SubscribeBuilderBase.C
      * @see #addSubscription(Mqtt5Subscription)
      */
     @CheckReturnValue
-    @NotNull Mqtt5SubscriptionBuilder.Nested<? extends C> addSubscription();
+    Mqtt5SubscriptionBuilder.@NotNull Nested<? extends C> addSubscription();
 
     /**
      * Adds {@link Mqtt5Subscription}s to the {@link Mqtt5Subscribe#getSubscriptions() list of subscriptions}. At least
@@ -118,7 +118,7 @@ public interface Mqtt5SubscribeBuilderBase<C extends Mqtt5SubscribeBuilderBase.C
          * @see #userProperties(Mqtt5UserProperties)
          */
         @CheckReturnValue
-        @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends C> userProperties();
+        Mqtt5UserPropertiesBuilder.@NotNull Nested<? extends C> userProperties();
     }
 
     /**

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilderBase.java
@@ -62,7 +62,7 @@ public interface Mqtt5SubscriptionBuilderBase<C extends Mqtt5SubscriptionBuilder
      * @see #topicFilter(MqttTopicFilter)
      */
     @CheckReturnValue
-    @NotNull MqttTopicFilterBuilder.Nested<? extends C> topicFilter();
+    MqttTopicFilterBuilder.@NotNull Nested<? extends C> topicFilter();
 
     /**
      * {@link Mqtt5SubscriptionBuilderBase} that is complete which means all mandatory fields are set.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/unsubscribe/Mqtt5Unsubscribe.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/unsubscribe/Mqtt5Unsubscribe.java
@@ -41,7 +41,7 @@ public interface Mqtt5Unsubscribe extends Mqtt5Message {
      *
      * @return the created builder.
      */
-    static @NotNull Mqtt5UnsubscribeBuilder.Start builder() {
+    static Mqtt5UnsubscribeBuilder.@NotNull Start builder() {
         return new MqttUnsubscribeBuilder.Default();
     }
 
@@ -65,5 +65,5 @@ public interface Mqtt5Unsubscribe extends Mqtt5Message {
      *
      * @return the created builder.
      */
-    @NotNull Mqtt5UnsubscribeBuilder.Complete extend();
+    Mqtt5UnsubscribeBuilder.@NotNull Complete extend();
 }

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilderBase.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilderBase.java
@@ -69,7 +69,7 @@ public interface Mqtt5UnsubscribeBuilderBase<C extends Mqtt5UnsubscribeBuilderBa
      * @see #addTopicFilter(MqttTopicFilter)
      */
     @CheckReturnValue
-    @NotNull MqttTopicFilterBuilder.Nested<? extends C> addTopicFilter();
+    MqttTopicFilterBuilder.@NotNull Nested<? extends C> addTopicFilter();
 
     /**
      * Adds {@link MqttTopicFilter Topic Filters} to the {@link Mqtt5Unsubscribe#getTopicFilters() list of Topic
@@ -140,7 +140,7 @@ public interface Mqtt5UnsubscribeBuilderBase<C extends Mqtt5UnsubscribeBuilderBa
          * @see #userProperties(Mqtt5UserProperties)
          */
         @CheckReturnValue
-        @NotNull Mqtt5UserPropertiesBuilder.Nested<? extends C> userProperties();
+        Mqtt5UserPropertiesBuilder.@NotNull Nested<? extends C> userProperties();
     }
 
     /**
@@ -180,6 +180,6 @@ public interface Mqtt5UnsubscribeBuilderBase<C extends Mqtt5UnsubscribeBuilderBa
          * @see #addTopicFilter(MqttTopicFilter)
          */
         @CheckReturnValue
-        @NotNull MqttTopicFilterBuilder.Nested<? extends C> topicFilter();
+        MqttTopicFilterBuilder.@NotNull Nested<? extends C> topicFilter();
     }
 }


### PR DESCRIPTION
**Motivation**
Resolve IDE warnings
The new annotation placement for nested classes may seem strange but is the only correct way as defined by Java.

**Changes**
- Cleaned up annotation placement for nested classes