### PR TITLE
Bugfix/cleanup event loops

### DIFF
--- a/src/main/java/com/hivemq/client/internal/mqtt/MqttClientConfig.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/MqttClientConfig.java
@@ -197,6 +197,7 @@ public class MqttClientConfig implements Mqtt5ClientConfig {
                     synchronized (state) {
                         if (eventLoopAcquireCount == this.eventLoopAcquireCount) { // eventLoop has not been reacquired
                             this.eventLoop = null;
+                            // releaseEventLoop must be the last statement so everything is cleaned up even if it throws
                             NettyEventLoopProvider.INSTANCE.releaseEventLoop(executorConfig.getRawNettyExecutor());
                         }
                     }

--- a/src/main/java/com/hivemq/client/internal/netty/NettyEventLoopProvider.java
+++ b/src/main/java/com/hivemq/client/internal/netty/NettyEventLoopProvider.java
@@ -90,8 +90,9 @@ public class NettyEventLoopProvider {
         if (entry == null) {
             final MultithreadEventLoopGroup eventLoopGroup;
             if (executor == null) {
-                eventLoopGroup = eventLoopGroupFactory.apply(threadCount,
-                        new ThreadPerTaskExecutor(new DefaultThreadFactory("com.hivemq.client.mqtt")));
+                eventLoopGroup = eventLoopGroupFactory.apply(
+                        threadCount, new ThreadPerTaskExecutor(
+                                new DefaultThreadFactory("com.hivemq.client.mqtt", Thread.MAX_PRIORITY)));
 
             } else if (executor instanceof MultithreadEventLoopGroup) {
                 eventLoopGroup = (MultithreadEventLoopGroup) executor;

--- a/src/main/java/com/hivemq/client/internal/netty/NettyEventLoopProvider.java
+++ b/src/main/java/com/hivemq/client/internal/netty/NettyEventLoopProvider.java
@@ -119,10 +119,11 @@ public class NettyEventLoopProvider {
     public synchronized void releaseEventLoop(final @Nullable Executor executor) {
         final Entry entry = entries.get(executor);
         if (--entry.referenceCount == 0) {
+            entries.remove(executor);
             if (!(executor instanceof MultithreadEventLoopGroup)) {
+                // shutdownGracefully must be the last statement so everything is cleaned up even if it throws
                 entry.eventLoopGroup.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
             }
-            entries.remove(executor);
         }
     }
 


### PR DESCRIPTION
**Motivation**
Resolves #445 

**Changes**
- Cleanup everything before shutting down event loop to be safe even if it throws
- Use Thread.MAX_PRIORITY for event loops (same as in MultithreadEventLoopGroup)