### PR TITLE
fixed jitpack.yml, removed jitpack badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 # HiveMQ MQTT Client
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.hivemq/hivemq-mqtt-client/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.hivemq/hivemq-mqtt-client)
-[![JitPack](https://jitpack.io/v/hivemq/hivemq-mqtt-client.svg)](https://jitpack.io/#hivemq/hivemq-mqtt-client)
 [![javadoc](https://javadoc.io/badge2/com.hivemq/hivemq-mqtt-client/javadoc.svg)](https://javadoc.io/doc/com.hivemq/hivemq-mqtt-client)
 [![Build Status](https://travis-ci.com/hivemq/hivemq-mqtt-client.svg?branch=develop)](https://travis-ci.com/hivemq/hivemq-mqtt-client)
 [![Language grade: Java](https://img.shields.io/lgtm/grade/java/g/hivemq/hivemq-mqtt-client.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/hivemq/hivemq-mqtt-client/context:java)

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 install:
-  ./gradlew publishToMavenLocal
+  ./gradlew publishToMavenLocal -x signBasePublication -x signShadedPublication


### PR DESCRIPTION
**Motivation**
With directly publishing to maven central jitpack fails because the sign tasks need secrets

**Changes**
- Do not run the sign tasks for jitpack
- Temporarily remove jitpack badge