### PR TITLE
[CI-CD] remove concurrency group

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,10 +4,6 @@ on:
   release:
     types: [ published ]
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   publish:
     environment: mavenCentralPublish


### PR DESCRIPTION
Remove the concurrency group from the publish workflow.

As creating a GitHub Release also crates a tag which triggers the check workflow a clash can happen because both workflows share the same concurrency group. 