### PR TITLE
Added the field localCorrelationData to MqttPublish for better flow-handling in reactive-APIs

### DIFF
--- a/src/main/java/com/hivemq/client/internal/mqtt/message/publish/MqttPublish.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/publish/MqttPublish.java
@@ -59,6 +59,7 @@ public class MqttPublish extends MqttMessageWithUserProperties implements Mqtt5P
     private final @Nullable MqttUtf8StringImpl contentType;
     private final @Nullable MqttTopicImpl responseTopic;
     private final @Nullable ByteBuffer correlationData;
+    private final @Nullable Object localCorrelationData;
 
     private final @Nullable Confirmable confirmable;
 
@@ -73,7 +74,8 @@ public class MqttPublish extends MqttMessageWithUserProperties implements Mqtt5P
             final @Nullable MqttTopicImpl responseTopic,
             final @Nullable ByteBuffer correlationData,
             final @NotNull MqttUserPropertiesImpl userProperties,
-            final @Nullable Confirmable confirmable) {
+            final @Nullable Confirmable confirmable,
+            final @Nullable Object localCorrelationData) {
 
         super(userProperties);
         this.topic = topic;
@@ -86,6 +88,24 @@ public class MqttPublish extends MqttMessageWithUserProperties implements Mqtt5P
         this.responseTopic = responseTopic;
         this.correlationData = correlationData;
         this.confirmable = confirmable;
+        this.localCorrelationData = localCorrelationData;
+    }
+
+    public MqttPublish(
+            final @NotNull MqttTopicImpl topic,
+            final @Nullable ByteBuffer payload,
+            final @NotNull MqttQos qos,
+            final boolean retain,
+            final long messageExpiryInterval,
+            final @Nullable Mqtt5PayloadFormatIndicator payloadFormatIndicator,
+            final @Nullable MqttUtf8StringImpl contentType,
+            final @Nullable MqttTopicImpl responseTopic,
+            final @Nullable ByteBuffer correlationData,
+            final @NotNull MqttUserPropertiesImpl userProperties,
+            final @Nullable Confirmable confirmable) {
+
+        this(topic, payload, qos, retain, messageExpiryInterval, payloadFormatIndicator, contentType,
+                responseTopic, correlationData, userProperties, confirmable, null);
     }
 
     @Override
@@ -163,6 +183,10 @@ public class MqttPublish extends MqttMessageWithUserProperties implements Mqtt5P
         return correlationData;
     }
 
+    public @Nullable Object getLocalCorrelationData() {
+        return localCorrelationData;
+    }
+
     @Override
     public void acknowledge() {
         final Confirmable confirmable = this.confirmable;
@@ -204,7 +228,7 @@ public class MqttPublish extends MqttMessageWithUserProperties implements Mqtt5P
 
     public @NotNull MqttPublish withConfirmable(final @NotNull Confirmable confirmable) {
         return new MqttPublish(topic, payload, qos, retain, messageExpiryInterval, payloadFormatIndicator, contentType,
-                responseTopic, correlationData, getUserProperties(), confirmable);
+                responseTopic, correlationData, getUserProperties(), confirmable, localCorrelationData);
     }
 
     @Override
@@ -216,6 +240,7 @@ public class MqttPublish extends MqttMessageWithUserProperties implements Mqtt5P
                 ((contentType == null) ? "" : ", contentType=" + contentType) +
                 ((responseTopic == null) ? "" : ", responseTopic=" + responseTopic) +
                 ((correlationData == null) ? "" : ", correlationData=" + correlationData.remaining() + "byte") +
+                ((localCorrelationData == null) ? "" : ", localCorrelationData=" + localCorrelationData + " " + localCorrelationData.getClass().getSimpleName()) +
                 StringUtil.prepend(", ", super.toAttributeString());
     }
 
@@ -239,7 +264,7 @@ public class MqttPublish extends MqttMessageWithUserProperties implements Mqtt5P
                 (messageExpiryInterval == that.messageExpiryInterval) &&
                 (payloadFormatIndicator == that.payloadFormatIndicator) &&
                 Objects.equals(contentType, that.contentType) && Objects.equals(responseTopic, that.responseTopic) &&
-                Objects.equals(correlationData, that.correlationData);
+                Objects.equals(correlationData, that.correlationData) && Objects.equals(localCorrelationData, that.localCorrelationData);
     }
 
     protected boolean canEqual(final @Nullable Object o) {
@@ -258,6 +283,7 @@ public class MqttPublish extends MqttMessageWithUserProperties implements Mqtt5P
         result = 31 * result + Objects.hashCode(contentType);
         result = 31 * result + Objects.hashCode(responseTopic);
         result = 31 * result + Objects.hashCode(correlationData);
+        result = 31 * result + Objects.hashCode(localCorrelationData);
         return result;
     }
 }

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/publish/MqttPublishBuilder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/publish/MqttPublishBuilder.java
@@ -47,6 +47,7 @@ public abstract class MqttPublishBuilder<B extends MqttPublishBuilder<B>> {
     @Nullable MqttUtf8StringImpl contentType;
     @Nullable MqttTopicImpl responseTopic;
     @Nullable ByteBuffer correlationData;
+    @Nullable Object localCorrelationData;
     @NotNull MqttUserPropertiesImpl userProperties = MqttUserPropertiesImpl.NO_USER_PROPERTIES;
 
     MqttPublishBuilder() {}
@@ -62,6 +63,7 @@ public abstract class MqttPublishBuilder<B extends MqttPublishBuilder<B>> {
         responseTopic = publish.getRawResponseTopic();
         correlationData = publish.getRawCorrelationData();
         userProperties = publish.getUserProperties();
+        localCorrelationData = publish.getLocalCorrelationData();
     }
 
     MqttPublishBuilder(final @NotNull MqttPublishBuilder<?> publishBuilder) {
@@ -152,6 +154,11 @@ public abstract class MqttPublishBuilder<B extends MqttPublishBuilder<B>> {
         return self();
     }
 
+    public @NotNull B localCorrelationData(final @Nullable Object localCorrelationData) {
+        this.localCorrelationData = localCorrelationData;
+        return self();
+    }
+
     public @NotNull B userProperties(final @Nullable Mqtt5UserProperties userProperties) {
         this.userProperties = MqttChecks.userProperties(userProperties);
         return self();
@@ -186,7 +193,7 @@ public abstract class MqttPublishBuilder<B extends MqttPublishBuilder<B>> {
         public @NotNull MqttPublish build() {
             Checks.notNull(topic, "Topic");
             return new MqttPublish(topic, payload, qos, retain, messageExpiryInterval, payloadFormatIndicator,
-                    contentType, responseTopic, correlationData, userProperties, null);
+                    contentType, responseTopic, correlationData, userProperties, null, localCorrelationData);
         }
     }
 

--- a/src/main/java/com/hivemq/client/internal/mqtt/message/publish/mqtt3/Mqtt3PublishView.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/message/publish/mqtt3/Mqtt3PublishView.java
@@ -50,8 +50,18 @@ public class Mqtt3PublishView implements Mqtt3Publish {
             final @NotNull MqttQos qos,
             final boolean retain) {
 
+        return delegate(topic, payload, qos, retain, null);
+    }
+
+    public static @NotNull MqttPublish delegate(
+            final @NotNull MqttTopicImpl topic,
+            final @Nullable ByteBuffer payload,
+            final @NotNull MqttQos qos,
+            final boolean retain,
+            final Object localCorrelationData) {
+
         return new MqttPublish(topic, payload, qos, retain, MqttPublish.NO_MESSAGE_EXPIRY, null, null, null, null,
-                MqttUserPropertiesImpl.NO_USER_PROPERTIES, null);
+                MqttUserPropertiesImpl.NO_USER_PROPERTIES, null, localCorrelationData);
     }
 
     public static @NotNull MqttStatefulPublish statefulDelegate(
@@ -122,6 +132,11 @@ public class Mqtt3PublishView implements Mqtt3Publish {
 
     public @NotNull MqttPublish getDelegate() {
         return delegate;
+    }
+
+    @Override
+    public Object localCorrelationData() {
+        return delegate.getLocalCorrelationData();
     }
 
     @Override

--- a/src/main/java/com/hivemq/client/mqtt/mqtt3/message/publish/Mqtt3Publish.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt3/message/publish/Mqtt3Publish.java
@@ -78,6 +78,12 @@ public interface Mqtt3Publish extends Mqtt3Message {
     boolean isRetain();
 
     /**
+     * @return the optional local correlation data of this Publish message. This data is never propagated and kept
+     * locally for correlation.
+     */
+    Object localCorrelationData();
+
+    /**
      * Acknowledges this Publish message.
      *
      * @throws UnsupportedOperationException if manual acknowledgement is not enabled.

--- a/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5Publish.java
+++ b/src/main/java/com/hivemq/client/mqtt/mqtt5/message/publish/Mqtt5Publish.java
@@ -110,6 +110,12 @@ public interface Mqtt5Publish extends Mqtt5Message {
     @NotNull Mqtt5UserProperties getUserProperties();
 
     /**
+     * @return the optional local correlation data of this Publish message. This data is never propagated and kept
+     * locally for correlation.
+     */
+    Object getLocalCorrelationData();
+
+    /**
      * Acknowledges this Publish message.
      *
      * @throws UnsupportedOperationException if manual acknowledgement is not enabled.


### PR DESCRIPTION
**Motivation**
Using the reactive integrations (rxjava2/reactor) results in a situation where after an MqttPublish has been processed a Mqtt5PublishResult is forward in the stream. This object doesn't contain any processing context which makes a few usecases rather unintuitive to implement.
In my case I am receiving from Kafka and want to commit AFTER the message has been sent to HiveMQ. For that I need to get the commit-offset to the end of the stream.


**Changes**
To support the above mentioned usecase I added a localCorrelationData (similar to what Kafka is doing in their client-lib). This field is never propagated to HiveMQ but can be used down the streams. In my case I store the Kafka-Commit-Offset in there and use it to trigger the actual commit.