### PR TITLE
added graalvm native image reflect config for a seamless experience

### DIFF
--- a/src/main/resources/META-INF/native-image/com.hivemq/hivemq-mqtt-client/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/com.hivemq/hivemq-mqtt-client/reflect-config.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "org.jctools.queues.BaseSpscLinkedArrayQueueConsumerField",
+    "fields": [
+      {
+        "name": "consumerIndex"
+      }
+    ]
+  },
+  {
+    "name": "org.jctools.queues.BaseSpscLinkedArrayQueueProducerFields",
+    "fields": [
+      {
+        "name": "producerIndex"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Description

This changes adds the required graalvm reflection config for the two missing fields. This config is picked up by graalvm during native compilation and registers the two fields for reflective access on the compiled native image java app.
See [here](https://www.graalvm.org/22.0/reference-manual/native-image/Reflection/) for more details.

## Related Issue

https://github.com/hivemq/hivemq-mqtt-client/issues/448

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've written tests (if applicable) for all new methods and classes that I created. 
- [x] I've added documentation as necessary so users can easily use and understand this feature/fix.
