### PR TITLE
Upgrade Netty to 4.1.99.Final

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ prevVersion=1.3.1
 #
 rxjava.version=2.2.21
 reactive-streams.version=1.0.4
-netty.version=4.1.48.Final
+netty.version=4.1.99.Final
 jctools.version=2.1.2
 annotations.version=16.0.3
 dagger.version=2.27


### PR DESCRIPTION
## Description

This upgrades Netty to address:

* CVE-2021-37136
* CVE-2021-37137
* CVE-2022-41915

It also fixes a bug when using JDK21+.

## Related Issue

Closes #503

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. 
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
