### PR TITLE
feature: client disconnect due to publish malformed topic

### DIFF
--- a/src/main/java/com/hivemq/client/internal/mqtt/codec/decoder/MqttDecoder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/codec/decoder/MqttDecoder.java
@@ -120,7 +120,7 @@ public class MqttDecoder extends ByteToMessageDecoder {
                     "Exception while decoding " + ((type == null) ? "UNKNOWN" : type) + ": " + e.getMessage();
             if (Mqtt5DisconnectReasonCode.TOPIC_NAME_INVALID.equals(e.getReasonCode()) &&
                     Mqtt5MessageType.PUBLISH.equals(type)) {
-                // PUBLISH message catch malformed topic, print log, don't disconnect
+                // PUBLISH message catch malformed topic, print log and  don't disconnect
                 LOGGER.error(message);
             } else {
                 MqttDisconnectUtil.disconnect(ctx.channel(), e.getReasonCode(), new MqttDecodeException(message));

--- a/src/main/java/com/hivemq/client/internal/mqtt/codec/decoder/MqttDecoder.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/codec/decoder/MqttDecoder.java
@@ -120,7 +120,7 @@ public class MqttDecoder extends ByteToMessageDecoder {
                     "Exception while decoding " + ((type == null) ? "UNKNOWN" : type) + ": " + e.getMessage();
             if (Mqtt5DisconnectReasonCode.TOPIC_NAME_INVALID.equals(e.getReasonCode()) &&
                     Mqtt5MessageType.PUBLISH.equals(type)) {
-                // PUBLISH message catch malformed topic, print log and  don't disconnect
+                // PUBLISH message catch malformed topic, print log and  don't disconnect 
                 LOGGER.error(message);
             } else {
                 MqttDisconnectUtil.disconnect(ctx.channel(), e.getReasonCode(), new MqttDecodeException(message));


### PR DESCRIPTION
## Description
resolve issue problem #515 if hivemqtt-client receive message which topic is malformed from mqtt borker, ignore this message and don't disconnect
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. 
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
