### PR TITLE
Change event loop to use daemon instead of non-daemon threads

### DIFF
--- a/src/main/java/com/hivemq/client/internal/netty/NettyEventLoopProvider.java
+++ b/src/main/java/com/hivemq/client/internal/netty/NettyEventLoopProvider.java
@@ -90,9 +90,10 @@ public class NettyEventLoopProvider {
         if (entry == null) {
             final MultithreadEventLoopGroup eventLoopGroup;
             if (executor == null) {
+                final boolean useDaemonThreads = true;
                 eventLoopGroup = eventLoopGroupFactory.apply(
                         threadCount, new ThreadPerTaskExecutor(
-                                new DefaultThreadFactory("com.hivemq.client.mqtt", Thread.MAX_PRIORITY)));
+                                new DefaultThreadFactory("com.hivemq.client.mqtt", useDaemonThreads, Thread.MAX_PRIORITY)));
 
             } else if (executor instanceof MultithreadEventLoopGroup) {
                 eventLoopGroup = (MultithreadEventLoopGroup) executor;


### PR DESCRIPTION
The class io.netty.util.concurrent.DefaultThreadFactory defaults to non-daemon thread if not explicitly configured. Threads created with defaults by this ThreadFactory might prevent unaware applcations from quitting.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. 
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
