### PR TITLE
Exclude Dagger tracking file from shaded JAR

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -223,6 +223,7 @@ tasks.shadowJar {
     relocate("org.jctools", "${shadePrefix}org.jctools")
     relocate("org.jetbrains", "${shadePrefix}org.jetbrains")
     relocate("dagger", "${shadePrefix}dagger")
+    exclude("META-INF/com.google.dagger_dagger.version")
     relocate("javax.inject", "${shadePrefix}javax.inject")
 
     minimize()

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ awaitility.version=4.2.2
 #
 # plugins
 #
-plugin.shadow.version=5.2.0
+plugin.shadow.version=6.1.0
 plugin.bnd.version=5.3.0
 plugin.nexus-publish.version=1.2.0
 plugin.license.version=0.15.0


### PR DESCRIPTION
## Description

Fixes https://github.com/hivemq/hivemq-mqtt-client/issues/651

Tested locally with JDK 8 and `./gradlew shadowJar`.

## Related Issue

The shadow plugin needs to be updated for the exclusion to work, see https://github.com/GradleUp/shadow/issues/505 (6.x is the last major version to work with our Gradle version)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix