### PR TITLE
Add on event so that PRs targeting master also run check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,9 @@
 name: CI Check
 
-on: [ push ]
+on:
+  push:
+  pull_request:
+    branches: [ master ]
 
 concurrency:
   group: ${{ github.ref }}


### PR DESCRIPTION
## Description

Add **on** event so that PRs targeting master also run check workflow

## Related Issue

Wanting to merge #681 but the check workflow is not triggered.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. 
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
