### PR TITLE
Fix broken openhab icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ backpressure support.
 ](https://github.com/bmwcarit) &nbsp;&nbsp; [
 <img src="https://github.com/bmwcarit/joynr/raw/master/graphics/joynr-logo.png" alt="joynr" height="60px"/>
 ](https://github.com/bmwcarit/joynr) &nbsp;&nbsp; [
-<img src="https://www.openhab.org/openhab-logo.png" alt="openHAB" height="60px"/>
+<img src="https://www.openhab.org/openhab-logo-square.svg" alt="openHAB" height="60px"/>
 ](https://www.openhab.org/) &nbsp;&nbsp; [
 <img src="https://eclipse.org/ditto/images/ditto.svg" alt="Eclipse Ditto" height="60px"/>
 ](https://github.com/eclipse/ditto) &nbsp;&nbsp; [


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
In the README.md the openhab icon link points to a 404 page. This PR intends to fix that.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. 
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
