### PR TITLE
fix issue with double encoding of mqtt presigned urls

### DIFF
--- a/src/main/java/com/hivemq/client/internal/mqtt/handler/websocket/MqttWebSocketInitializer.java
+++ b/src/main/java/com/hivemq/client/internal/mqtt/handler/websocket/MqttWebSocketInitializer.java
@@ -21,20 +21,26 @@ import com.hivemq.client.internal.mqtt.MqttClientTransportConfigImpl;
 import com.hivemq.client.internal.mqtt.MqttWebSocketConfigImpl;
 import com.hivemq.client.internal.mqtt.datatypes.MqttVariableByteInteger;
 import com.hivemq.client.internal.mqtt.ioc.ConnectionScope;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.UnsupportedEncodingException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import javax.inject.Inject;
+
 import io.netty.channel.Channel;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
-import org.jetbrains.annotations.NotNull;
-
-import javax.inject.Inject;
-import java.net.InetSocketAddress;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 /**
  * @author Silvio Giebl
@@ -52,6 +58,42 @@ public class MqttWebSocketInitializer {
         this.mqttWebSocketCodec = mqttWebSocketCodec;
     }
 
+    /**
+     * Builds the WebSocket URI without double-encoding the query string.
+     * <p>
+     * Query strings (especially AWS IoT presigned URLs) may already be URL-encoded. Using the multi-argument URI
+     * constructor would encode them again, breaking signatures. This method first builds the URI (which double-encodes),
+     * then decodes it back to restore the original encoding.
+     *
+     * @param scheme      the URI scheme (ws or wss)
+     * @param host        the host
+     * @param port        the port
+     * @param serverPath  the WebSocket server path
+     * @param queryString the query string (may be pre-encoded)
+     * @return the constructed URI
+     * @throws URISyntaxException           if the URI is malformed
+     * @throws UnsupportedEncodingException if UTF-8 encoding is not supported
+     * @see <a href="https://github.com/hivemq/hivemq-mqtt-client/issues/421">GitHub Issue #421</a>
+     */
+    static @NotNull URI buildWebSocketUri(
+            final @NotNull String scheme,
+            final @NotNull String host,
+            final int port,
+            final @NotNull String serverPath,
+            final @NotNull String queryString) throws URISyntaxException, UnsupportedEncodingException {
+
+        // For empty/null query strings, build URI without query to avoid trailing '?'
+        if (queryString == null || queryString.isEmpty()) {
+            return new URI(scheme, null, host, port, "/" + serverPath, null, null);
+        }
+
+        // The multi-argument URI constructor encodes the query string, which double-encodes
+        // already-encoded query strings (like AWS presigned URLs). We decode the entire URI
+        // to reverse this double-encoding.
+        final URI encodedUri = new URI(scheme, null, host, port, "/" + serverPath, queryString, null);
+        return new URI(URLDecoder.decode(encodedUri.toString(), StandardCharsets.UTF_8.toString()));
+    }
+
     public void initChannel(
             final @NotNull Channel channel,
             final @NotNull MqttClientConfig clientConfig,
@@ -63,10 +105,10 @@ public class MqttWebSocketInitializer {
         try {
             final MqttClientTransportConfigImpl transportConfig = clientConfig.getCurrentTransportConfig();
             final InetSocketAddress serverAddress = transportConfig.getServerAddress();
-            uri = new URI((transportConfig.getRawSslConfig() == null) ? "ws" : "wss", null,
-                    serverAddress.getHostString(), serverAddress.getPort(), "/" + webSocketConfig.getServerPath(),
-                    webSocketConfig.getQueryString(), null);
-        } catch (final URISyntaxException e) {
+            final String scheme = (transportConfig.getRawSslConfig() == null) ? "ws" : "wss";
+            uri = buildWebSocketUri(scheme, serverAddress.getHostString(), serverAddress.getPort(),
+                    webSocketConfig.getServerPath(), webSocketConfig.getQueryString());
+        } catch (final URISyntaxException | UnsupportedEncodingException e) {
             onError.accept(channel, e);
             return;
         }

--- a/src/test/java/com/hivemq/client/internal/mqtt/handler/websocket/MqttWebSocketInitializerTest.java
+++ b/src/test/java/com/hivemq/client/internal/mqtt/handler/websocket/MqttWebSocketInitializerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018-present HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hivemq.client.internal.mqtt.handler.websocket;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Tests for WebSocket URI construction, specifically verifying that pre-encoded query strings
+ * (such as AWS IoT presigned URLs) are not double-encoded.
+ *
+ * @see <a href="https://github.com/hivemq/hivemq-mqtt-client/issues/421">GitHub Issue #421</a>
+ */
+class MqttWebSocketInitializerTest {
+
+    @Test
+    void emptyQueryString_shouldProduceValidUri() throws URISyntaxException, UnsupportedEncodingException {
+        final URI uri = MqttWebSocketInitializer.buildWebSocketUri("wss", "example.com", 443, "mqtt", "");
+        assertEquals("wss://example.com:443/mqtt", uri.toString());
+    }
+
+    @Test
+    void nullQueryString_shouldProduceValidUri() throws URISyntaxException, UnsupportedEncodingException {
+        final URI uri = MqttWebSocketInitializer.buildWebSocketUri("wss", "example.com", 443, "mqtt", null);
+        assertEquals("wss://example.com:443/mqtt", uri.toString());
+    }
+
+    @Test
+    void simpleQueryString_shouldNotBeEncoded() throws URISyntaxException, UnsupportedEncodingException {
+        final URI uri = MqttWebSocketInitializer.buildWebSocketUri("wss", "example.com", 443, "mqtt", "clientId=test");
+        assertEquals("wss://example.com:443/mqtt?clientId=test", uri.toString());
+    }
+
+    @Test
+    void multipleQueryParams_shouldPreserveStructure() throws URISyntaxException, UnsupportedEncodingException {
+        final URI uri = MqttWebSocketInitializer.buildWebSocketUri("wss", "example.com", 443, "mqtt", "clientId=test&clean=true");
+        assertEquals("wss://example.com:443/mqtt?clientId=test&clean=true", uri.toString());
+    }
+
+    @Test
+    void preEncodedQueryString_shouldNotBeDoubleEncoded() throws URISyntaxException, UnsupportedEncodingException {
+        // AWS IoT presigned URLs contain already-encoded characters like %2F, %3D
+        // This test verifies they are NOT double-encoded (which would turn %2F into %252F)
+        final String preEncodedQuery = "X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA%2F20231001%2Fus-east-1%2Fiot";
+        final URI uri = MqttWebSocketInitializer.buildWebSocketUri("wss", "iot.amazonaws.com", 443, "mqtt", preEncodedQuery);
+
+        // The query string should be preserved as-is, not double-encoded
+        final String uriString = uri.toString();
+        assertEquals("wss://iot.amazonaws.com:443/mqtt?" + preEncodedQuery, uriString);
+
+        // Verify %2F was NOT double-encoded to %252F
+        assertFalse(uriString.contains("%252F"), "Query string was double-encoded - %2F became %252F");
+    }
+
+    @Test
+    void complexAwsPresignedUrl_shouldPreserveSignature() throws URISyntaxException, UnsupportedEncodingException {
+        // Realistic AWS IoT Core presigned URL query string
+        final String awsPresignedQuery = "X-Amz-Algorithm=AWS4-HMAC-SHA256" +
+                "&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20231201%2Fus-east-1%2Fiotdevicegateway%2Faws4_request" +
+                "&X-Amz-Date=20231201T120000Z" +
+                "&X-Amz-SignedHeaders=host" +
+                "&X-Amz-Signature=abcd1234signature5678";
+
+        final URI uri = MqttWebSocketInitializer.buildWebSocketUri("wss", "iot.us-east-1.amazonaws.com", 443, "mqtt", awsPresignedQuery);
+
+        // Verify the URI contains the query exactly as provided
+        final String uriString = uri.toString();
+        assertEquals("wss://iot.us-east-1.amazonaws.com:443/mqtt?" + awsPresignedQuery, uriString);
+    }
+
+    @Test
+    void wsScheme_shouldWorkWithoutSsl() throws URISyntaxException, UnsupportedEncodingException {
+        final URI uri = MqttWebSocketInitializer.buildWebSocketUri("ws", "localhost", 8080, "mqtt", "test=value");
+        assertEquals("ws://localhost:8080/mqtt?test=value", uri.toString());
+    }
+
+    @Test
+    void pathWithSubdirectory_shouldBePreserved() throws URISyntaxException, UnsupportedEncodingException {
+        final URI uri = MqttWebSocketInitializer.buildWebSocketUri("wss", "example.com", 443, "api/v1/mqtt", "token=abc");
+        assertEquals("wss://example.com:443/api/v1/mqtt?token=abc", uri.toString());
+    }
+
+    /**
+     * This test demonstrates the bug that existed before the fix.
+     * With the old implementation using URI(scheme, null, host, port, path, query, null),
+     * the query string would be encoded, causing pre-encoded strings to be double-encoded.
+     */
+    @Test
+    void oldBehavior_wouldDoubleEncode() throws URISyntaxException {
+        // This is how the OLD implementation built the URI:
+        final URI oldStyleUri = new URI("wss", null, "example.com", 443, "/mqtt",
+                "credential=AKIA%2F20231001", null);
+
+        // The old implementation would double-encode, turning %2F into %252F
+        final String oldUriString = oldStyleUri.toString();
+        // This assertion shows the bug: %2F becomes %252F
+        assertEquals("wss://example.com:443/mqtt?credential=AKIA%252F20231001", oldUriString,
+                "This demonstrates the double-encoding bug in the old implementation");
+    }
+}


### PR DESCRIPTION
## Description

This fixes a bug found when using AWS presigned urls - the consensus is that the url was being double encoded and therefore always resulting in a 403

## Related Issue

https://github.com/hivemq/hivemq-mqtt-client/issues/643
https://community.hivemq.com/t/connect-mqtt-broker-with-pre-signed-url/751/8

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've written tests (if applicable) for all new methods and classes that I created. 
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
