### PR TITLE
[LATEST] PLATFORM: Upgrade toolchain to Java 25

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ jobs:
           distribution: temurin
           java-version: |
             8
-            21
+            25
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
           distribution: temurin
           java-version: |
             8
-            21
+            25
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
         with:

--- a/.github/workflows/snyk-pr.yml
+++ b/.github/workflows/snyk-pr.yml
@@ -28,8 +28,7 @@ jobs:
           distribution: temurin
           java-version: |
             8
-            11
-            21
+            25
 
       - name: Check for new issues
         uses: hivemq/hivemq-snyk-composite-action@1c18f39e10e7b1d35fa121b91b99c0445b7a4a56 # v2

--- a/.github/workflows/snyk-push.yml
+++ b/.github/workflows/snyk-push.yml
@@ -37,8 +37,7 @@ jobs:
           distribution: temurin
           java-version: |
             8
-            11
-            21
+            25
 
       - name: Setup Snyk
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1

--- a/.github/workflows/snyk-release.yml
+++ b/.github/workflows/snyk-release.yml
@@ -21,8 +21,7 @@ jobs:
           distribution: temurin
           java-version: |
             8
-            11
-            21
+            25
 
       - name: Setup Snyk
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # HiveMQ MQTT Client
 
-[![Maven Central](https://maven-badges.sml.io/maven-central/com.hivemq/hivemq-mqtt-client/badge.svg)](https://central.sonatype.com/artifact/com.hivemq/hivemq-mqtt-client)
+[![Maven Central](https://maven-badges.sml.io/maven-central/com.hivemq/hivemq-mqtt-client/badge.svg)](https://maven-badges.sml.io/sonatype-central/com.hivemq/hivemq-mqtt-client)
 [![javadoc](https://javadoc.io/badge2/com.hivemq/hivemq-mqtt-client/javadoc.svg)](https://javadoc.io/doc/com.hivemq/hivemq-mqtt-client)
 [![GitHub Workflow Status (branch)](https://img.shields.io/github/actions/workflow/status/hivemq/hivemq-mqtt-client/.github/workflows/check.yml?branch=master)](https://img.shields.io/github/actions/workflow/status/hivemq/hivemq-mqtt-client/.github/workflows/check.yml?branch=master)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
     plugins.withId("java") {
         java {
             toolchain {
-                languageVersion = JavaLanguageVersion.of(21)
+                languageVersion = JavaLanguageVersion.of(25)
             }
         }
         tasks.compileJava {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -151,6 +151,12 @@ sourceSets.create("integrationTest") {
     runtimeClasspath += sourceSets.main.get().output
 }
 
+tasks.named<JavaCompile>("compileIntegrationTestJava") {
+    // The integration tests bundle a HiveMQ extension that is loaded inside the HiveMQ CE container (Java 21).
+    // Compile to Java 21 bytecode so the container can load it, independent of the (Java 25) build toolchain.
+    options.release.set(21)
+}
+
 val integrationTestImplementation: Configuration by configurations.getting {
     extendsFrom(configurations.testImplementation.get())
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,9 +82,9 @@ dependencies {
     implementation(libs.netty.handler)
     implementation(libs.netty.transport)
     implementation(libs.jctools)
-    implementation(libs.jetbrains.annotations)
     implementation(libs.dagger)
 
+    compileOnlyApi(libs.jetbrains.annotations)
     compileOnly(libs.slf4j.api)
 
     annotationProcessor(libs.dagger.compiler)
@@ -133,6 +133,9 @@ dependencies {
     testImplementation(libs.bouncycastle.pkix)
     testImplementation(libs.bouncycastle.prov)
     testImplementation(libs.paho.client)
+    // EqualsVerifier reflects on @NotNull/@Nullable at runtime; compileOnlyApi is compile-only,
+    // so the annotations must be added to the test runtime classpath explicitly.
+    testRuntimeOnly(libs.jetbrains.annotations)
     testRuntimeOnly(libs.slf4j.simple)
 }
 
@@ -249,17 +252,9 @@ tasks.shadowJar {
     relocate("META-INF/native/libnetty", "META-INF/native/lib${shadeFilePrefix}netty")
     exclude("META-INF/io.netty.versions.properties")
     relocate("org.jctools", "${shadePrefix}org.jctools")
-    relocate("org.jetbrains", "${shadePrefix}org.jetbrains")
     relocate("dagger", "${shadePrefix}dagger")
     exclude("META-INF/com.google.dagger_dagger.version")
     relocate("javax.inject", "${shadePrefix}javax.inject")
-    // Drops the relocated org.jetbrains:annotations kotlin_module
-    // (META-INF/annotations.shadow.kotlin_module) from the shaded jar and silences the
-    // shadow 9.5.0+ DuplicatesStrategy=EXCLUDE warning it triggers. Safe to remove: the file
-    // only describes the shaded-internal org.jetbrains.annotations package (nothing compiles
-    // Kotlin against it) and those annotation types carry no top-level/internal/multifile
-    // declarations, so no Kotlin compiler or runtime ever reads it.
-    exclude("META-INF/*.kotlin_module")
 
     minimize()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,6 +119,9 @@ allprojects {
             maxHeapSize = "1g"
             maxParallelForks = 1.coerceAtLeast(Runtime.getRuntime().availableProcessors() / 2)
             jvmArgs("-XX:+UseParallelGC")
+            // Netty uses sun.misc.Unsafe and native libraries; silence the Java 24+ warnings.
+            // See https://netty.io/wiki/java-24-and-sun.misc.unsafe.html
+            jvmArgs("--sun-misc-unsafe-memory-access=allow", "--enable-native-access=ALL-UNNAMED")
         }
     }
 }
@@ -174,6 +177,9 @@ val integrationTest by tasks.registering(Test::class) {
     testClassesDirs = sourceSets["integrationTest"].output.classesDirs
     classpath = sourceSets["integrationTest"].runtimeClasspath
     shouldRunAfter(tasks.test)
+    // Netty uses sun.misc.Unsafe and native libraries; silence the Java 24+ warnings.
+    // See https://netty.io/wiki/java-24-and-sun.misc.unsafe.html
+    jvmArgs("--sun-misc-unsafe-memory-access=allow", "--enable-native-access=ALL-UNNAMED")
 }
 
 oci.of(integrationTest) {

--- a/reactor/build.gradle.kts
+++ b/reactor/build.gradle.kts
@@ -19,7 +19,8 @@ dependencies {
     api(libs.reactor)
 
     implementation(libs.reactor.adapter)
-    implementation(libs.jetbrains.annotations)
+
+    compileOnlyApi(libs.jetbrains.annotations)
 }
 
 /* ******************** test ******************** */


### PR DESCRIPTION
Upgrade the build toolchain to Java 25. Compile target stays at Java 8.

Part of INT-8 and INT-394.